### PR TITLE
Fix N+1 query problem on gene expression page

### DIFF
--- a/source/org/zfin/expression/repository/ExpressionRepository.java
+++ b/source/org/zfin/expression/repository/ExpressionRepository.java
@@ -432,6 +432,8 @@ public interface ExpressionRepository {
 
     ExpressionResult2 getExpressionResult2(long id);
 
+    List<ExpressionResult2> getExpressionResult2sByIds(Collection<Long> ids);
+
     List<ExpressionExperiment2> getExpressionExperiment2ByPub(String pubID, String geneID);
 
     List<ExpressionFigureStage> getExperimentFigureStagesByIds(List<Integer> expressionIDs);

--- a/source/org/zfin/expression/repository/HibernateExpressionRepository.java
+++ b/source/org/zfin/expression/repository/HibernateExpressionRepository.java
@@ -2072,6 +2072,30 @@ public class HibernateExpressionRepository implements ExpressionRepository {
         return expressionResult2;
     }
 
+    @Override
+    public List<ExpressionResult2> getExpressionResult2sByIds(Collection<Long> ids) {
+        if (ids == null || ids.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Session session = currentSession();
+        return session.createQuery("""
+                select distinct er from ExpressionResult2 er
+                    left join fetch er.expressionFigureStage efs
+                    left join fetch efs.startStage
+                    left join fetch efs.endStage
+                    left join fetch efs.expressionExperiment ee
+                    left join fetch ee.fishExperiment fe
+                    left join fetch fe.fish f
+                    left join fetch f.genotype
+                    left join fetch fe.experiment
+                    left join fetch er.superTerm
+                    left join fetch er.subTerm
+                where er.id in (:ids)
+                """, ExpressionResult2.class)
+                .setParameterList("ids", ids)
+                .list();
+    }
+
     public List<ExpressionFigureStage> getExperimentFigureStagesByIds(List<Integer> expressionIDs) {
         Session session = HibernateUtil.currentSession();
 

--- a/source/org/zfin/expression/service/ExpressionSearchService.java
+++ b/source/org/zfin/expression/service/ExpressionSearchService.java
@@ -249,8 +249,22 @@ public class ExpressionSearchService {
         criteria.setNumFound(queryResponse.getGroupResponse().getValues().get(0).getNGroups());
         criteria.setPubCount(queryResponse.getGroupResponse().getValues().get(1).getNGroups());
 
-        return queryResponse.getGroupResponse().getValues().get(0).getValues().stream()
-                .map(this::buildFigureResult)
+        List<Group> figureGroups = queryResponse.getGroupResponse().getValues().get(0).getValues();
+
+        // Batch-load all expression results in one query instead of N+1
+        Set<Long> allExpressionResultIds = figureGroups.stream()
+                .flatMap(group -> group.getResult().stream())
+                .flatMap(doc -> ((ArrayList<String>) doc.get(FieldName.XPATRES_ID.getName())).stream())
+                .distinct()
+                .map(Long::parseLong)
+                .collect(Collectors.toSet());
+
+        Map<Long, ExpressionResult2> expressionResultMap = expressionRepository
+                .getExpressionResult2sByIds(allExpressionResultIds).stream()
+                .collect(Collectors.toMap(ExpressionResult2::getID, Function.identity()));
+
+        return figureGroups.stream()
+                .map(group -> buildFigureResult(group, expressionResultMap))
                 .collect(Collectors.toList());
     }
 
@@ -284,7 +298,7 @@ public class ExpressionSearchService {
                 .collect(Collectors.toList());
     }
 
-    private FigureResult buildFigureResult(Group group) {
+    private FigureResult buildFigureResult(Group group, Map<Long, ExpressionResult2> expressionResultMap) {
         FigureResult figureResult = new FigureResult();
 
         Figure figure = figureRepository.getFigure(group.getGroupValue());
@@ -294,7 +308,8 @@ public class ExpressionSearchService {
         List<ExpressionResult2> results = group.getResult().stream()
                 .flatMap(doc -> ((ArrayList<String>) doc.get(FieldName.XPATRES_ID.getName())).stream())
                 .distinct()
-                .map(id -> expressionRepository.getExpressionResult2(Integer.parseInt(id)))
+                .map(Long::parseLong)
+                .map(expressionResultMap::get)
                 .filter(Objects::nonNull)
                 .filter(ExpressionResult2::isExpressionFound)
                 .collect(Collectors.toList());


### PR DESCRIPTION
The expression results page was issuing 371 DB queries per request due to loading each ExpressionResult2 individually by PK (106 queries) plus lazy-loading ExpressionFigureStage, terms, fish, and experiments (71+ queries). Added a batch-loading method getExpressionResult2sByIds() with eager fetch joins for the full association chain, and refactored getFigureResults() to collect all IDs upfront and batch-load in a single query. Reduces total DB queries from 371 to 163.