### PR TITLE
Add run report to RNACentral ID loader

### DIFF
--- a/server_apps/data_transfer/RNACentral/LoadRNACentralIDs.groovy
+++ b/server_apps/data_transfer/RNACentral/LoadRNACentralIDs.groovy
@@ -3,6 +3,14 @@
 import org.zfin.properties.ZfinProperties
 import org.zfin.util.ReportGenerator
 import static com.xlson.groovycsv.CsvParser.parseCsv
+import groovy.cli.commons.CliBuilder
+
+cli = new CliBuilder(usage: 'LoadRNACentralIDs')
+cli.jobName(args: 1, 'Name of the job to be displayed in report')
+options = cli.parse(args)
+if (!options) {
+    System.exit(1)
+}
 
 
 ZfinProperties.init("${System.getenv()['ZFIN_PROPERTIES_PATH']}")
@@ -41,11 +49,16 @@ File inputFile = new File("zfin.tsv")
 
 dbname = System.getenv("DBNAME")
 println("Loading terms into $dbname")
+PRE_FILE = "preRNAcentral.unl"
+POST_FILE = "postRNAcentral.unl"
+COUNTS_FILE = "rnaCentralCounts.unl"
 
 
 psql dbname, """
 
 DROP TABLE if exists tmp_rnac_zfin;
+
+\\copy (SELECT dblink_linked_recid, dblink_acc_num FROM db_link WHERE dblink_fdbcont_zdb_id = (SELECT fdbcont_zdb_id FROM foreign_db, foreign_db_contains WHERE fdbcont_fdb_db_id = fdb_db_pk_id AND fdb_db_name LIKE 'RNA Central')) TO '$PRE_FILE';
 
 CREATE TEMP TABLE tmp_rnac_zfin (
     rnacid text,
@@ -58,13 +71,16 @@ CREATE TEMP TABLE tmp_rnac_zfin (
 
 \\copy tmp_rnac_zfin FROM 'zfin.tsv' WITH delimiter E'\\t';
 
- 
-
-
-
+DROP TABLE if exists tmp_rnac_counts;
+CREATE TEMP TABLE tmp_rnac_counts (metric text, count bigint);
+INSERT INTO tmp_rnac_counts SELECT 'downloaded', count(*) FROM tmp_rnac_zfin;
 
 delete from tmp_rnac_zfin where tscriptid not in (select tscript_mrkr_zdb_id from transcript);
+INSERT INTO tmp_rnac_counts SELECT 'after_transcript_filter', count(*) FROM tmp_rnac_zfin;
+
 delete from tmp_rnac_zfin where trim(rnacid) in (select trim(dblink_acc_num) from db_link where dblink_acc_num like 'URS%');
+INSERT INTO tmp_rnac_counts SELECT 'inserted', count(*) FROM tmp_rnac_zfin;
+
 alter table tmp_rnac_zfin add column dblinkid text;
 alter table tmp_rnac_zfin add column fdbcontid text;
 
@@ -79,10 +95,51 @@ insert into db_link (dblink_linked_recid,dblink_acc_num, dblink_zdb_id ,dblink_a
 insert into record_attribution (recattrib_data_zdb_id, recattrib_source_zdb_id)
 select dblinkid,'ZDB-PUB-200928-1' from tmp_rnac_zfin;
 
+\\copy (SELECT dblink_linked_recid, dblink_acc_num FROM db_link WHERE dblink_fdbcont_zdb_id = (SELECT fdbcont_zdb_id FROM foreign_db, foreign_db_contains WHERE fdbcont_fdb_db_id = fdb_db_pk_id AND fdb_db_name LIKE 'RNA Central')) TO '$POST_FILE';
+
+\\copy tmp_rnac_counts TO '$COUNTS_FILE';
+
 """
+println("done with script")
 
+if (options.jobName) {
+    // Running from Jenkins; generate a report.
+    def counts = [:]
+    new File(COUNTS_FILE).eachLine { line ->
+        def parts = line.split("\t")
+        if (parts.size() == 2) {
+            counts[parts[0]] = parts[1] as long
+        }
+    }
 
+    def downloaded = counts.get('downloaded', 0L)
+    def afterTranscriptFilter = counts.get('after_transcript_filter', 0L)
+    def inserted = counts.get('inserted', 0L)
+    def droppedNoTranscript = downloaded - afterTranscriptFilter
+    def droppedAlreadyLoaded = afterTranscriptFilter - inserted
 
+    def preLines = new File(PRE_FILE).readLines()
+    def postLines = new File(POST_FILE).readLines()
+    def added = postLines - preLines
+    def removed = preLines - postLines
+
+    new ReportGenerator().with {
+        setReportTitle("Report for ${options.jobName}")
+        includeTimestamp()
+        addSummaryTable("Load summary", [
+                "Rows downloaded from RNAcentral": downloaded,
+                "Dropped (transcript not in ZFIN)": droppedNoTranscript,
+                "Dropped (already loaded)": droppedAlreadyLoaded,
+                "Inserted into db_link": inserted,
+        ])
+        addDataTable("${added.size()} db_links added", ["Transcript ID", "RNA Central ID"],
+                added.collect { it.split("\t") as List })
+        addDataTable("${removed.size()} db_links removed", ["Transcript ID", "RNA Central ID"],
+                removed.collect { it.split("\t") as List })
+        writeFiles(new File("."), "loadRNACentralReport")
+    }
+}
+System.exit(0)
 
 
 

--- a/server_apps/jenkins/jobs/Load-RNACentralLinks_m/config.xml
+++ b/server_apps/jenkins/jobs/Load-RNACentralLinks_m/config.xml
@@ -22,11 +22,11 @@
     </hudson.tasks.Shell>
   </builders>
   <publishers>
-   <!-- <hudson.tasks.ArtifactArchiver>
-      &lt;!&ndash;<artifacts>server_apps/data_transfer/Panther/loadAGRReport*</artifacts>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>server_apps/data_transfer/RNACentral/loadRNACentralReport.*</artifacts>
       <latestOnly>false</latestOnly>
-      <allowEmptyArchive>false</allowEmptyArchive>&ndash;&gt;
-    </hudson.tasks.ArtifactArchiver>-->
+      <allowEmptyArchive>false</allowEmptyArchive>
+    </hudson.tasks.ArtifactArchiver>
     <hudson.plugins.emailext.ExtendedEmailPublisher plugin="email-ext@2.35.1">
       <recipientList>$DEFAULT_RECIPIENTS</recipientList>
       <configuredTriggers>
@@ -34,10 +34,10 @@
           <email>
             <recipientList>@FAILURE-RECIPIENT-LIST@</recipientList>
             <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <!--<body>${FILE,path=&quot;$TARGETROOT/server_apps/data_transfer/Panther/loadAGRReport.html&quot;}
+            <body>${FILE,path=&quot;$TARGETROOT/server_apps/data_transfer/RNACentral/loadRNACentralReport.html&quot;}
 
               See report on Jenkins dashboard: &lt;a href=&quot;${BUILD_URL}&quot;&gt;${BUILD_URL}&lt;/a&gt;
-            </body>-->
+            </body>
             <sendToDevelopers>false</sendToDevelopers>
             <sendToRequester>false</sendToRequester>
             <includeCulprits>false</includeCulprits>
@@ -53,10 +53,10 @@
           <email>
             <recipientList>@SUCCESS-RECIPIENT-LIST@</recipientList>
            <subject>$PROJECT_DEFAULT_SUBJECT</subject>
-            <!-- <body>${FILE,path=&quot;$TARGETROOT/server_apps/data_transfer/Panther/alliance-report.html&quot;}
+            <body>${FILE,path=&quot;$TARGETROOT/server_apps/data_transfer/RNACentral/loadRNACentralReport.html&quot;}
 
               See report on Jenkins dashboard: &lt;a href=&quot;${BUILD_URL}&quot;&gt;${BUILD_URL}&lt;/a&gt;
-            </body>-->
+            </body>
             <sendToDevelopers>false</sendToDevelopers>
             <sendToRequester>false</sendToRequester>
             <includeCulprits>false</includeCulprits>


### PR DESCRIPTION
LoadRNACentralIDs.groovy now parses -jobName, captures pre/post snapshots of the RNA Central db_link rows and per-stage row counts, then emits loadRNACentralReport.{html,txt,xlsx,csv} summarizing rows downloaded, dropped (no matching transcript, already loaded), and inserted, along with added/removed tables.

Enable the Jenkins archiver for the report files and wire the success and failure email bodies to embed loadRNACentralReport.html.