### PR TITLE
ZFIN-10304: comments, section approval, and status overview bar

### DIFF
--- a/conf/hibernate.cfg.xml
+++ b/conf/hibernate.cfg.xml
@@ -331,6 +331,8 @@
 
         <!-- ZIRC line submission entities -->
         <mapping class="org.zfin.zirc.entity.LineSubmission"/>
+        <mapping class="org.zfin.zirc.entity.LineSubmissionComment"/>
+        <mapping class="org.zfin.zirc.entity.LineSubmissionSectionApproval"/>
         <mapping class="org.zfin.zirc.entity.LineSubmissionPerson"/>
         <mapping class="org.zfin.zirc.entity.LinkedFeature"/>
         <mapping class="org.zfin.zirc.entity.Mutation"/>

--- a/home/WEB-INF/jsp/zirc/line-submission-detail.jsp
+++ b/home/WEB-INF/jsp/zirc/line-submission-detail.jsp
@@ -67,7 +67,8 @@
         </style>
 
         <div class="small text-uppercase text-muted">ZIRC Line Submission</div>
-        <h1><z:zirc-status-badge status="${overallStatus}"/> ${submission.name}<z:zirc-section-history key="submission" label="Line Submission ${submission.name}" updates="${submissionAllUpdates}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="section" sectionName="submission" label="Line Submission ${submission.name}"/></h1>
+        <%-- submission.name is curator-entered; escape on every direct HTML emission. --%>
+        <h1><z:zirc-status-badge status="${overallStatus}"/> <c:out value="${submission.name}"/><z:zirc-section-history key="submission" label="Line Submission ${submission.name}" updates="${submissionAllUpdates}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="section" sectionName="submission" label="Line Submission ${submission.name}"/></h1>
 
         <%-- Workflow status bar: first three cells display data, the rest
              mirror the page's top-level sections and turn green when that

--- a/home/WEB-INF/jsp/zirc/line-submission-detail.jsp
+++ b/home/WEB-INF/jsp/zirc/line-submission-detail.jsp
@@ -41,13 +41,99 @@
             .section .heading:hover .field-history-trigger,
             .field-history-trigger:focus,
             .field-history-trigger:hover { opacity: 1; }
+
+            /* Workflow-stage status bar at the top of the page. */
+            .status-overview-bar { border-collapse: collapse; }
+            .status-overview-bar th, .status-overview-bar td {
+                border: 1px solid #333;
+                font-size: 0.75rem;
+                line-height: 1.1;
+                text-align: center;
+                vertical-align: middle;
+                padding: 0.35rem 0.4rem;
+                min-width: 4.5em;
+                max-width: 6.5em;
+            }
+            .status-overview-bar th { font-weight: 600; background: #fff; }
+            .status-overview-bar td.data-cell    { background: #fffbe6; font-weight: 500; }
+            .status-overview-bar td.status-cell  { height: 2.2em; background: #fff; }
+            /* Match the FieldStatus badge palette so a quick glance at the
+               bar tells you the rollup state — red=Missing, amber=In
+               Progress, green=Complete, blue=Approved. */
+            .status-overview-bar td.status-cell.status-missing     { background: #dc3545; }
+            .status-overview-bar td.status-cell.status-in-progress { background: #ffc107; }
+            .status-overview-bar td.status-cell.status-complete    { background: #4f9c4a; }
+            .status-overview-bar td.status-cell.status-approved    { background: #007bff; }
         </style>
 
         <div class="small text-uppercase text-muted">ZIRC Line Submission</div>
-        <h1><z:zirc-status-badge status="${overallStatus}"/> ${submission.name}<z:zirc-section-history key="submission" label="Line Submission ${submission.name}" updates="${submissionAllUpdates}"/></h1>
+        <h1><z:zirc-status-badge status="${overallStatus}"/> ${submission.name}<z:zirc-section-history key="submission" label="Line Submission ${submission.name}" updates="${submissionAllUpdates}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="section" sectionName="submission" label="Line Submission ${submission.name}"/></h1>
 
-        <c:set var="overviewBadge"><z:zirc-status-badge status="${sectionStatus['Overview']}"/><z:zirc-section-history key="overview" label="Overview" updates="${sectionUpdates['Overview']}"/></c:set>
-        <z:section title="${OVERVIEW}" prependedText="${overviewBadge}">
+        <%-- Workflow status bar: first three cells display data, the rest
+             mirror the page's top-level sections and turn green when that
+             section's status is COMPLETE or APPROVED. Cell clicks jump
+             to the matching section anchor. --%>
+        <h5 class="mt-3 mb-1">Status Overview
+            <small class="status-legend text-muted ml-3">
+                <span class="badge badge-danger">M</span>&nbsp;Missing
+                <span class="badge badge-warning ml-2">IP</span>&nbsp;In&nbsp;Progress
+                <span class="badge badge-success ml-2">C</span>&nbsp;Complete
+                <span class="badge badge-primary ml-2">A</span>&nbsp;Approved
+            </small>
+        </h5>
+        <table class="status-overview-bar mb-4">
+            <thead>
+                <tr>
+                    <th>Submitter</th>
+                    <th>Line</th>
+                    <th>Submission<br/>date</th>
+                    <th>Overview</th>
+                    <th>Mutations</th>
+                    <th>Linked<br/>Features</th>
+                    <th>Background</th>
+                    <th>Additional<br/>Info</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td class="data-cell">
+                        <c:choose>
+                            <c:when test="${not empty submission.persons}"><c:forEach items="${submission.persons}" var="lsp" varStatus="lspLoop"><c:if test="${not empty lsp.person.firstName}">${fn:substring(lsp.person.firstName, 0, 1)}. </c:if><c:out value="${lsp.person.lastName}"/><c:if test="${!lspLoop.last}">, </c:if></c:forEach></c:when>
+                            <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
+                        </c:choose>
+                    </td>
+                    <td class="data-cell">
+                        <c:choose>
+                            <c:when test="${not empty submission.name}"><c:out value="${submission.name}"/></c:when>
+                            <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
+                        </c:choose>
+                    </td>
+                    <td class="data-cell">
+                        <c:choose>
+                            <c:when test="${not empty submission.createdAt}"><fmt:formatDate value="${submission.createdAt}" pattern="yyyy-MM-dd"/></c:when>
+                            <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
+                        </c:choose>
+                    </td>
+                    <c:forEach var="sec" items="${[['Overview', OVERVIEW], ['Mutations', MUTATIONS], ['Linked Features', LINKED_FEATURES], ['Background', BACKGROUND], ['Additional Info', ADDITIONAL]]}">
+                        <c:set var="sStatus" value="${sectionStatus[sec[0]]}"/>
+                        <c:set var="statusName" value="${sStatus == null ? '' : sStatus.name()}"/>
+                        <c:set var="statusClass" value=""/>
+                        <c:if test="${statusName == 'MISSING'}">    <c:set var="statusClass" value="status-missing"/></c:if>
+                        <c:if test="${statusName == 'IN_PROGRESS'}"><c:set var="statusClass" value="status-in-progress"/></c:if>
+                        <c:if test="${statusName == 'COMPLETE'}">   <c:set var="statusClass" value="status-complete"/></c:if>
+                        <c:if test="${statusName == 'APPROVED'}">   <c:set var="statusClass" value="status-approved"/></c:if>
+                        <c:set var="secDomId" value="${zfn:makeDomIdentifier(sec[1])}"/>
+                        <td class="status-cell ${statusClass}" data-section-id="${secDomId}" title="${sec[0]}: ${sStatus == null ? '—' : sStatus.displayName}">
+                            <a href="#${secDomId}" class="d-block w-100 h-100 text-decoration-none">&nbsp;</a>
+                        </td>
+                    </c:forEach>
+                </tr>
+            </tbody>
+        </table>
+
+        <c:set var="overviewBadge"><z:zirc-status-badge status="${sectionStatus['Overview']}"/><z:zirc-section-history key="overview" label="Overview" updates="${sectionUpdates['Overview']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="section" sectionName="overview" label="Overview"/></c:set>
+        <c:set var="overviewApproval"><z:zirc-section-approval recId="${submission.zdbID}" sectionName="overview" approved="${sectionApprovals[submission.zdbID.concat('|overview')]}" enabled="${(sectionStatus['Overview'] != null) and (sectionStatus['Overview'].name() == 'COMPLETE' or sectionStatus['Overview'].name() == 'APPROVED')}"/></c:set>
+        <z:section title="${OVERVIEW}" prependedText="${overviewBadge}" appendedText="${overviewApproval}">
             <table class="table table-borderless w-auto">
                 <tbody>
                     <tr>
@@ -67,7 +153,7 @@
                                 <c:when test="${not empty submission.name}"><c:out value="${submission.name}"/></c:when>
                                 <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                             </c:choose>
-                            <z:zirc-field-history fieldName="name" label="Name" updates="${fieldUpdates['name']}"/>
+                            <z:zirc-field-history fieldName="name" label="Name" updates="${fieldUpdates['name']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="field" fieldName="name" label="Name"/>
                         </td>
                     </tr>
                     <tr>
@@ -77,16 +163,14 @@
                                 <c:when test="${not empty submission.previousNames}"><c:out value="${submission.previousNames}"/></c:when>
                                 <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                             </c:choose>
-                            <z:zirc-field-history fieldName="previousNames" label="Previous Names" updates="${fieldUpdates['previousNames']}"/>
+                            <z:zirc-field-history fieldName="previousNames" label="Previous Names" updates="${fieldUpdates['previousNames']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="field" fieldName="previousNames" label="Previous Names"/>
                         </td>
                     </tr>
                     <tr>
-                        <th><span class="status-slot"></span>Date Started</th>
-                        <td><fmt:formatDate value="${submission.createdAt}" pattern="yyyy-MM-dd HH:mm"/></td>
-                    </tr>
-                    <tr>
-                        <th><span class="status-slot"></span>Last Updated</th>
-                        <td><fmt:formatDate value="${submission.updatedAt}" pattern="yyyy-MM-dd HH:mm"/></td>
+                        <th><span class="status-slot"></span>Date Started - Last Updated</th>
+                        <td>
+                            <fmt:formatDate value="${submission.createdAt}" pattern="yyyy-MM-dd HH:mm"/> - <fmt:formatDate value="${submission.updatedAt}" pattern="yyyy-MM-dd HH:mm"/>
+                        </td>
                     </tr>
                     <tr>
                         <th><span class="status-slot"></span>Submitter</th>
@@ -121,16 +205,17 @@
                                     <c:if test="${not empty submission.reasonsOther}"><c:if test="${not empty submission.reasons}">, </c:if>Other: <c:out value="${submission.reasonsOther}"/></c:if>
                                 </c:otherwise>
                             </c:choose>
-                            <z:zirc-field-history fieldName="reasons" label="Acceptance Reasons" updates="${fieldUpdates['reasons']}"/>
-                            <z:zirc-field-history fieldName="reasonsOther" label="Acceptance Reasons (Other)" updates="${fieldUpdates['reasonsOther']}"/>
+                            <z:zirc-field-history fieldName="reasons" label="Acceptance Reasons" updates="${fieldUpdates['reasons']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="field" fieldName="reasons" label="Acceptance Reasons"/>
+                            <z:zirc-field-history fieldName="reasonsOther" label="Acceptance Reasons (Other)" updates="${fieldUpdates['reasonsOther']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="field" fieldName="reasonsOther" label="Acceptance Reasons (Other)"/>
                         </td>
                     </tr>
                 </tbody>
             </table>
         </z:section>
 
-        <c:set var="mutationsBadge"><z:zirc-status-badge status="${sectionStatus['Mutations']}"/><z:zirc-section-history key="mutations" label="Mutations" updates="${sectionUpdates['Mutations']}"/></c:set>
-        <z:section title="${MUTATIONS}" prependedText="${mutationsBadge}">
+        <c:set var="mutationsBadge"><z:zirc-status-badge status="${sectionStatus['Mutations']}"/><z:zirc-section-history key="mutations" label="Mutations" updates="${sectionUpdates['Mutations']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="section" sectionName="mutations" label="Mutations"/></c:set>
+        <c:set var="mutationsApproval"><z:zirc-section-approval recId="${submission.zdbID}" sectionName="mutations" approved="${sectionApprovals[submission.zdbID.concat('|mutations')]}" enabled="${(sectionStatus['Mutations'] != null) and (sectionStatus['Mutations'].name() == 'COMPLETE' or sectionStatus['Mutations'].name() == 'APPROVED')}"/></c:set>
+        <z:section title="${MUTATIONS}" prependedText="${mutationsBadge}" appendedText="${mutationsApproval}">
             <c:choose>
                 <c:when test="${empty submission.mutations}">
                     <p class="text-muted">No mutations recorded for this submission.</p>
@@ -140,23 +225,32 @@
                         <c:set var="mFieldStatus" value="${mutationFieldStatus[m.id]}"/>
                         <c:set var="mFieldUpdates" value="${mutationFieldUpdates[m.id]}"/>
                         <c:set var="mScope" value="mut${m.id}"/>
+                        <c:set var="mRecId" value="ZIRC-MUT-${m.id}"/>
                         <c:set var="mSectStat" value="${mutationSectionStatus[m.id]}"/>
                         <c:set var="mSectUpdates" value="${mutationSectionUpdates[m.id]}"/>
-                        <c:set var="mSectionBadge"><z:zirc-status-badge status="${mutationStatus[m.id]}"/><z:zirc-section-history key="mutation" label="Mutation ${loop.count}" updates="${mutationAllUpdates[m.id]}" scope="${mScope}"/></c:set>
-                        <c:set var="overviewBadge"><z:zirc-status-badge status="${mSectStat['Overview']}"/><z:zirc-section-history key="overview" label="Mutation ${loop.count} &mdash; Overview" updates="${mSectUpdates['Overview']}" scope="${mScope}"/></c:set>
-                        <c:set var="genesBadge"><z:zirc-status-badge status="${mSectStat['Genes']}"/><z:zirc-section-history key="genes" label="Mutation ${loop.count} &mdash; Genes" updates="${mSectUpdates['Genes']}" scope="${mScope}"/></c:set>
-                        <c:set var="lesionsBadge"><z:zirc-status-badge status="${mSectStat['Lesions']}"/><z:zirc-section-history key="lesions" label="Mutation ${loop.count} &mdash; Lesions" updates="${mSectUpdates['Lesions']}" scope="${mScope}"/></c:set>
-                        <c:set var="gaBadge"><z:zirc-status-badge status="${mSectStat['Genotyping Assays']}"/><z:zirc-section-history key="genotyping-assays" label="Mutation ${loop.count} &mdash; Genotyping Assays" updates="${mSectUpdates['Genotyping Assays']}" scope="${mScope}"/></c:set>
-                        <c:set var="phenoBadge"><z:zirc-status-badge status="${mSectStat['Phenotypes']}"/><z:zirc-section-history key="phenotypes" label="Mutation ${loop.count} &mdash; Phenotypes" updates="${mSectUpdates['Phenotypes']}" scope="${mScope}"/></c:set>
-                        <c:set var="lethalityBadge"><z:zirc-status-badge status="${mSectStat['Lethality']}"/><z:zirc-section-history key="lethality" label="Mutation ${loop.count} &mdash; Lethality" updates="${mSectUpdates['Lethality']}" scope="${mScope}"/></c:set>
+                        <c:set var="mSectionBadge"><z:zirc-status-badge status="${mutationStatus[m.id]}"/><z:zirc-section-history key="mutation" label="Mutation ${loop.count}" updates="${mutationAllUpdates[m.id]}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="section" sectionName="mutation" label="Mutation ${loop.count}"/></c:set>
+                        <c:set var="mSectionApproval"><z:zirc-section-approval recId="${mRecId}" sectionName="mutation" approved="${sectionApprovals[mRecId.concat('|mutation')]}" enabled="${(mutationStatus[m.id] != null) and (mutationStatus[m.id].name() == 'COMPLETE' or mutationStatus[m.id].name() == 'APPROVED')}"/></c:set>
+                        <c:set var="overviewBadge"><z:zirc-status-badge status="${mSectStat['Overview']}"/><z:zirc-section-history key="overview" label="Mutation ${loop.count} &mdash; Overview" updates="${mSectUpdates['Overview']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="section" sectionName="overview" label="Mutation ${loop.count} &mdash; Overview"/></c:set>
+                        <c:set var="overviewApproval"><z:zirc-section-approval recId="${mRecId}" sectionName="overview" approved="${sectionApprovals[mRecId.concat('|overview')]}" enabled="${(mSectStat['Overview'] != null) and (mSectStat['Overview'].name() == 'COMPLETE' or mSectStat['Overview'].name() == 'APPROVED')}"/></c:set>
+                        <c:set var="genesBadge"><z:zirc-status-badge status="${mSectStat['Genes']}"/><z:zirc-section-history key="genes" label="Mutation ${loop.count} &mdash; Genes" updates="${mSectUpdates['Genes']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="section" sectionName="genes" label="Mutation ${loop.count} &mdash; Genes"/></c:set>
+                        <c:set var="genesApproval"><z:zirc-section-approval recId="${mRecId}" sectionName="genes" approved="${sectionApprovals[mRecId.concat('|genes')]}" enabled="${(mSectStat['Genes'] != null) and (mSectStat['Genes'].name() == 'COMPLETE' or mSectStat['Genes'].name() == 'APPROVED')}"/></c:set>
+                        <c:set var="lesionsBadge"><z:zirc-status-badge status="${mSectStat['Lesions']}"/><z:zirc-section-history key="lesions" label="Mutation ${loop.count} &mdash; Lesions" updates="${mSectUpdates['Lesions']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="section" sectionName="lesions" label="Mutation ${loop.count} &mdash; Lesions"/></c:set>
+                        <c:set var="lesionsApproval"><z:zirc-section-approval recId="${mRecId}" sectionName="lesions" approved="${sectionApprovals[mRecId.concat('|lesions')]}" enabled="${(mSectStat['Lesions'] != null) and (mSectStat['Lesions'].name() == 'COMPLETE' or mSectStat['Lesions'].name() == 'APPROVED')}"/></c:set>
+                        <c:set var="gaBadge"><z:zirc-status-badge status="${mSectStat['Genotyping Assays']}"/><z:zirc-section-history key="genotyping-assays" label="Mutation ${loop.count} &mdash; Genotyping Assays" updates="${mSectUpdates['Genotyping Assays']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="section" sectionName="genotyping-assays" label="Mutation ${loop.count} &mdash; Genotyping Assays"/></c:set>
+                        <c:set var="gaApproval"><z:zirc-section-approval recId="${mRecId}" sectionName="genotyping-assays" approved="${sectionApprovals[mRecId.concat('|genotyping-assays')]}" enabled="${(mSectStat['Genotyping Assays'] != null) and (mSectStat['Genotyping Assays'].name() == 'COMPLETE' or mSectStat['Genotyping Assays'].name() == 'APPROVED')}"/></c:set>
+                        <c:set var="phenoBadge"><z:zirc-status-badge status="${mSectStat['Phenotypes']}"/><z:zirc-section-history key="phenotypes" label="Mutation ${loop.count} &mdash; Phenotypes" updates="${mSectUpdates['Phenotypes']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="section" sectionName="phenotypes" label="Mutation ${loop.count} &mdash; Phenotypes"/></c:set>
+                        <c:set var="phenoApproval"><z:zirc-section-approval recId="${mRecId}" sectionName="phenotypes" approved="${sectionApprovals[mRecId.concat('|phenotypes')]}" enabled="${(mSectStat['Phenotypes'] != null) and (mSectStat['Phenotypes'].name() == 'COMPLETE' or mSectStat['Phenotypes'].name() == 'APPROVED')}"/></c:set>
+                        <c:set var="lethalityBadge"><z:zirc-status-badge status="${mSectStat['Lethality']}"/><z:zirc-section-history key="lethality" label="Mutation ${loop.count} &mdash; Lethality" updates="${mSectUpdates['Lethality']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="section" sectionName="lethality" label="Mutation ${loop.count} &mdash; Lethality"/></c:set>
+                        <c:set var="lethalityApproval"><z:zirc-section-approval recId="${mRecId}" sectionName="lethality" approved="${sectionApprovals[mRecId.concat('|lethality')]}" enabled="${(mSectStat['Lethality'] != null) and (mSectStat['Lethality'].name() == 'COMPLETE' or mSectStat['Lethality'].name() == 'APPROVED')}"/></c:set>
                         <c:set var="pubsBadge"><z:zirc-status-badge status="${mSectStat['Publications']}"/></c:set>
-                        <z:section title="Mutation ${loop.count}" prependedText="${mSectionBadge}" cssClass="ml-4">
+                        <c:set var="pubsApproval"><z:zirc-section-approval recId="${mRecId}" sectionName="publications" approved="${sectionApprovals[mRecId.concat('|publications')]}" enabled="${(mSectStat['Publications'] != null) and (mSectStat['Publications'].name() == 'COMPLETE' or mSectStat['Publications'].name() == 'APPROVED')}"/></c:set>
+                        <z:section title="Mutation ${loop.count}" prependedText="${mSectionBadge}" appendedText="${mSectionApproval}" cssClass="ml-4">
                             <p class="text-right mb-2">
                                 <a class="btn btn-sm btn-outline-primary"
                                    href="/action/zirc/mutation/${m.id}/edit">Edit</a>
                             </p>
 
-                            <z:section title="Overview" prependedText="${overviewBadge}" cssClass="ml-4" sectionID="mutation-${loop.count}-overview">
+                            <z:section title="Overview" prependedText="${overviewBadge}" appendedText="${overviewApproval}" cssClass="ml-4" sectionID="mutation-${loop.count}-overview">
                                 <table class="table table-borderless w-auto">
                                     <tbody>
                                         <tr>
@@ -167,7 +261,7 @@
                                                     <c:when test="${m.alleleInZfin == false}">No</c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="alleleInZfin" label="Allele in ZFIN" updates="${mFieldUpdates['alleleInZfin']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="alleleInZfin" label="Allele in ZFIN" updates="${mFieldUpdates['alleleInZfin']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="alleleInZfin" label="Allele in ZFIN"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -177,7 +271,7 @@
                                                     <c:when test="${not empty m.alleleDesignation}"><c:out value="${m.alleleDesignation}"/></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="alleleDesignation" label="Allele Designation" updates="${mFieldUpdates['alleleDesignation']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="alleleDesignation" label="Allele Designation" updates="${mFieldUpdates['alleleDesignation']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="alleleDesignation" label="Allele Designation"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -187,7 +281,7 @@
                                                     <c:when test="${not empty m.mutagenesisStage}"><c:out value="${m.mutagenesisStage}"/></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="mutagenesisStage" label="Mutagenesis Stage" updates="${mFieldUpdates['mutagenesisStage']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="mutagenesisStage" label="Mutagenesis Stage" updates="${mFieldUpdates['mutagenesisStage']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="mutagenesisStage" label="Mutagenesis Stage"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -197,8 +291,8 @@
                                                     <c:when test="${not empty m.mutagenesisProtocol}"><c:out value="${m.mutagenesisProtocol}"/><c:if test="${m.mutagenesisProtocol == 'other' and not empty m.mutagenesisProtocolOther}"> (<c:out value="${m.mutagenesisProtocolOther}"/>)</c:if></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="mutagenesisProtocol" label="Mutagenesis Protocol" updates="${mFieldUpdates['mutagenesisProtocol']}" scope="${mScope}"/>
-                                                <z:zirc-field-history fieldName="mutagenesisProtocolOther" label="Mutagenesis Protocol (Other)" updates="${mFieldUpdates['mutagenesisProtocolOther']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="mutagenesisProtocol" label="Mutagenesis Protocol" updates="${mFieldUpdates['mutagenesisProtocol']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="mutagenesisProtocol" label="Mutagenesis Protocol"/>
+                                                <z:zirc-field-history fieldName="mutagenesisProtocolOther" label="Mutagenesis Protocol (Other)" updates="${mFieldUpdates['mutagenesisProtocolOther']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="mutagenesisProtocolOther" label="Mutagenesis Protocol (Other)"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -209,7 +303,7 @@
                                                     <c:when test="${m.molecularlyCharacterized == false}">No</c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="molecularlyCharacterized" label="Molecularly Characterized" updates="${mFieldUpdates['molecularlyCharacterized']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="molecularlyCharacterized" label="Molecularly Characterized" updates="${mFieldUpdates['molecularlyCharacterized']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="molecularlyCharacterized" label="Molecularly Characterized"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -219,7 +313,7 @@
                                                     <c:when test="${not empty m.mutationType}"><c:out value="${m.mutationType}"/></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="mutationType" label="Mutation Type" updates="${mFieldUpdates['mutationType']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="mutationType" label="Mutation Type" updates="${mFieldUpdates['mutationType']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="mutationType" label="Mutation Type"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -230,7 +324,7 @@
                                                     <c:when test="${m.zfinRecordEstablished == false}">No</c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="zfinRecordEstablished" label="ZFIN Record Established" updates="${mFieldUpdates['zfinRecordEstablished']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="zfinRecordEstablished" label="ZFIN Record Established" updates="${mFieldUpdates['zfinRecordEstablished']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="zfinRecordEstablished" label="ZFIN Record Established"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -240,7 +334,7 @@
                                                     <c:when test="${not empty m.cellGenomicFeature}"><c:out value="${m.cellGenomicFeature}"/></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="cellGenomicFeature" label="ZDB Genomic Feature #" updates="${mFieldUpdates['cellGenomicFeature']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="cellGenomicFeature" label="ZDB Genomic Feature #" updates="${mFieldUpdates['cellGenomicFeature']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="cellGenomicFeature" label="ZDB Genomic Feature #"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -250,7 +344,7 @@
                                                     <c:when test="${not empty m.mutationDiscoverer}"><c:out value="${m.mutationDiscoverer}"/></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="mutationDiscoverer" label="Discoverer" updates="${mFieldUpdates['mutationDiscoverer']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="mutationDiscoverer" label="Discoverer" updates="${mFieldUpdates['mutationDiscoverer']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="mutationDiscoverer" label="Discoverer"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -260,14 +354,14 @@
                                                     <c:when test="${not empty m.mutationInstitution}"><c:out value="${m.mutationInstitution}"/></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="mutationInstitution" label="Institution" updates="${mFieldUpdates['mutationInstitution']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="mutationInstitution" label="Institution" updates="${mFieldUpdates['mutationInstitution']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="mutationInstitution" label="Institution"/>
                                             </td>
                                         </tr>
                                     </tbody>
                                 </table>
                             </z:section>
 
-                            <z:section title="Genes" prependedText="${genesBadge}" cssClass="ml-4" sectionID="mutation-${loop.count}-genes">
+                            <z:section title="Genes" prependedText="${genesBadge}" appendedText="${genesApproval}" cssClass="ml-4" sectionID="mutation-${loop.count}-genes">
                                 <c:choose>
                                     <c:when test="${empty m.genes}">
                                         <p class="text-muted">No genes recorded.</p>
@@ -288,12 +382,13 @@
                                                     <c:set var="gFieldStatus" value="${geneFieldStatus[g.id]}"/>
                                                     <c:set var="gFieldUpdates" value="${geneFieldUpdates[g.id]}"/>
                                                     <c:set var="gScope" value="gene${g.id}"/>
+                                                    <c:set var="gRecId" value="ZIRC-GENE-${g.id}"/>
                                                     <tr>
                                                         <td>${gloop.count}</td>
-                                                        <td><z:zirc-status-badge status="${gFieldStatus['mutatedGene']}"/> <c:choose><c:when test="${not empty g.mutatedGene}"><a href="/${g.mutatedGene.zdbID}"><c:out value="${g.mutatedGene.abbreviation}"/></a></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="mutatedGene" label="Gene" updates="${gFieldUpdates['mutatedGene']}" scope="${gScope}"/></td>
-                                                        <td><z:zirc-status-badge status="${gFieldStatus['linkageGroup']}"/> <c:choose><c:when test="${not empty g.linkageGroup}"><c:out value="${g.linkageGroup}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="linkageGroup" label="Linkage Group" updates="${gFieldUpdates['linkageGroup']}" scope="${gScope}"/></td>
-                                                        <td><z:zirc-status-badge status="${gFieldStatus['genbankGenomicDna']}"/> <c:choose><c:when test="${not empty g.genbankGenomicDna}"><c:out value="${g.genbankGenomicDna}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="genbankGenomicDna" label="GenBank Genomic DNA" updates="${gFieldUpdates['genbankGenomicDna']}" scope="${gScope}"/></td>
-                                                        <td><z:zirc-status-badge status="${gFieldStatus['genbankCdna']}"/> <c:choose><c:when test="${not empty g.genbankCdna}"><c:out value="${g.genbankCdna}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="genbankCdna" label="GenBank cDNA" updates="${gFieldUpdates['genbankCdna']}" scope="${gScope}"/></td>
+                                                        <td><z:zirc-status-badge status="${gFieldStatus['mutatedGene']}"/> <c:choose><c:when test="${not empty g.mutatedGene}"><a href="/${g.mutatedGene.zdbID}"><c:out value="${g.mutatedGene.abbreviation}"/></a></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="mutatedGene" label="Gene" updates="${gFieldUpdates['mutatedGene']}" scope="${gScope}"/><z:zirc-field-comments recId="${gRecId}" scope="field" fieldName="mutatedGene" label="Gene"/></td>
+                                                        <td><z:zirc-status-badge status="${gFieldStatus['linkageGroup']}"/> <c:choose><c:when test="${not empty g.linkageGroup}"><c:out value="${g.linkageGroup}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="linkageGroup" label="Linkage Group" updates="${gFieldUpdates['linkageGroup']}" scope="${gScope}"/><z:zirc-field-comments recId="${gRecId}" scope="field" fieldName="linkageGroup" label="Linkage Group"/></td>
+                                                        <td><z:zirc-status-badge status="${gFieldStatus['genbankGenomicDna']}"/> <c:choose><c:when test="${not empty g.genbankGenomicDna}"><c:out value="${g.genbankGenomicDna}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="genbankGenomicDna" label="GenBank Genomic DNA" updates="${gFieldUpdates['genbankGenomicDna']}" scope="${gScope}"/><z:zirc-field-comments recId="${gRecId}" scope="field" fieldName="genbankGenomicDna" label="GenBank Genomic DNA"/></td>
+                                                        <td><z:zirc-status-badge status="${gFieldStatus['genbankCdna']}"/> <c:choose><c:when test="${not empty g.genbankCdna}"><c:out value="${g.genbankCdna}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="genbankCdna" label="GenBank cDNA" updates="${gFieldUpdates['genbankCdna']}" scope="${gScope}"/><z:zirc-field-comments recId="${gRecId}" scope="field" fieldName="genbankCdna" label="GenBank cDNA"/></td>
                                                     </tr>
                                                 </c:forEach>
                                             </tbody>
@@ -302,7 +397,7 @@
                                 </c:choose>
                             </z:section>
 
-                            <z:section title="Lesions" prependedText="${lesionsBadge}" cssClass="ml-4" sectionID="mutation-${loop.count}-lesions">
+                            <z:section title="Lesions" prependedText="${lesionsBadge}" appendedText="${lesionsApproval}" cssClass="ml-4" sectionID="mutation-${loop.count}-lesions">
                                 <c:choose>
                                     <c:when test="${empty m.lesions}">
                                         <p class="text-muted">No lesions recorded.</p>
@@ -312,37 +407,38 @@
                                             <c:set var="lzFieldStatus" value="${lesionFieldStatus[lz.id]}"/>
                                             <c:set var="lzFieldUpdates" value="${lesionFieldUpdates[lz.id]}"/>
                                             <c:set var="lzScope" value="lesion${lz.id}"/>
+                                            <c:set var="lzRecId" value="ZIRC-LESION-${lz.id}"/>
                                             <z:section title="Lesion ${lloop.count}" cssClass="ml-4">
                                                 <table class="table table-borderless w-auto">
                                                     <tbody>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['lesionType']}"/></span>Lesion Type</th>
-                                                            <td><c:choose><c:when test="${not empty lz.lesionType}"><c:out value="${lz.lesionType}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="lesionType" label="Lesion Type" updates="${lzFieldUpdates['lesionType']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.lesionType}"><c:out value="${lz.lesionType}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="lesionType" label="Lesion Type" updates="${lzFieldUpdates['lesionType']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="lesionType" label="Lesion Type"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['lesionSizeBp']}"/></span>Lesion Size (bp)</th>
-                                                            <td><c:choose><c:when test="${not empty lz.lesionSizeBp}">${lz.lesionSizeBp}</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="lesionSizeBp" label="Lesion Size (bp)" updates="${lzFieldUpdates['lesionSizeBp']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.lesionSizeBp}">${lz.lesionSizeBp}</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="lesionSizeBp" label="Lesion Size (bp)" updates="${lzFieldUpdates['lesionSizeBp']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="lesionSizeBp" label="Lesion Size (bp)"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['insertionSizeBp']}"/></span>Insertion Size (bp)</th>
-                                                            <td><c:choose><c:when test="${not empty lz.insertionSizeBp}">${lz.insertionSizeBp}</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="insertionSizeBp" label="Insertion Size (bp)" updates="${lzFieldUpdates['insertionSizeBp']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.insertionSizeBp}">${lz.insertionSizeBp}</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="insertionSizeBp" label="Insertion Size (bp)" updates="${lzFieldUpdates['insertionSizeBp']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="insertionSizeBp" label="Insertion Size (bp)"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['nucleotideChange']}"/></span>Nucleotide Change</th>
-                                                            <td><c:choose><c:when test="${not empty lz.nucleotideChange}"><c:out value="${lz.nucleotideChange}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="nucleotideChange" label="Nucleotide Change" updates="${lzFieldUpdates['nucleotideChange']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.nucleotideChange}"><c:out value="${lz.nucleotideChange}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="nucleotideChange" label="Nucleotide Change" updates="${lzFieldUpdates['nucleotideChange']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="nucleotideChange" label="Nucleotide Change"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['deletedSequence']}"/></span>Deleted Sequence</th>
-                                                            <td><c:choose><c:when test="${not empty lz.deletedSequence}"><c:out value="${lz.deletedSequence}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="deletedSequence" label="Deleted Sequence" updates="${lzFieldUpdates['deletedSequence']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.deletedSequence}"><c:out value="${lz.deletedSequence}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="deletedSequence" label="Deleted Sequence" updates="${lzFieldUpdates['deletedSequence']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="deletedSequence" label="Deleted Sequence"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['insertedSequence']}"/></span>Inserted Sequence</th>
-                                                            <td><c:choose><c:when test="${not empty lz.insertedSequence}"><c:out value="${lz.insertedSequence}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="insertedSequence" label="Inserted Sequence" updates="${lzFieldUpdates['insertedSequence']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.insertedSequence}"><c:out value="${lz.insertedSequence}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="insertedSequence" label="Inserted Sequence" updates="${lzFieldUpdates['insertedSequence']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="insertedSequence" label="Inserted Sequence"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['transgeneSequence']}"/></span>Transgene Sequence</th>
-                                                            <td><c:choose><c:when test="${not empty lz.transgeneSequence}"><c:out value="${lz.transgeneSequence}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="transgeneSequence" label="Transgene Sequence" updates="${lzFieldUpdates['transgeneSequence']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.transgeneSequence}"><c:out value="${lz.transgeneSequence}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="transgeneSequence" label="Transgene Sequence" updates="${lzFieldUpdates['transgeneSequence']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="transgeneSequence" label="Transgene Sequence"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['locationInline']}"/></span>Location (inline)</th>
-                                                            <td><c:choose><c:when test="${not empty lz.locationInline}"><c:out value="${lz.locationInline}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="locationInline" label="Location (inline)" updates="${lzFieldUpdates['locationInline']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.locationInline}"><c:out value="${lz.locationInline}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="locationInline" label="Location (inline)" updates="${lzFieldUpdates['locationInline']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="locationInline" label="Location (inline)"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['fivePrimeFlank']}"/></span>5' Flank</th>
-                                                            <td><c:choose><c:when test="${not empty lz.fivePrimeFlank}"><c:out value="${lz.fivePrimeFlank}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="fivePrimeFlank" label="5' Flank" updates="${lzFieldUpdates['fivePrimeFlank']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.fivePrimeFlank}"><c:out value="${lz.fivePrimeFlank}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="fivePrimeFlank" label="5' Flank" updates="${lzFieldUpdates['fivePrimeFlank']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="fivePrimeFlank" label="5' Flank"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['threePrimeFlank']}"/></span>3' Flank</th>
-                                                            <td><c:choose><c:when test="${not empty lz.threePrimeFlank}"><c:out value="${lz.threePrimeFlank}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="threePrimeFlank" label="3' Flank" updates="${lzFieldUpdates['threePrimeFlank']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.threePrimeFlank}"><c:out value="${lz.threePrimeFlank}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="threePrimeFlank" label="3' Flank" updates="${lzFieldUpdates['threePrimeFlank']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="threePrimeFlank" label="3' Flank"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['hasLargeVariant']}"/></span>Has Large Variant</th>
-                                                            <td><c:choose><c:when test="${lz.hasLargeVariant == true}">Yes</c:when><c:when test="${lz.hasLargeVariant == false}">No</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="hasLargeVariant" label="Has Large Variant" updates="${lzFieldUpdates['hasLargeVariant']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${lz.hasLargeVariant == true}">Yes</c:when><c:when test="${lz.hasLargeVariant == false}">No</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="hasLargeVariant" label="Has Large Variant" updates="${lzFieldUpdates['hasLargeVariant']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="hasLargeVariant" label="Has Large Variant"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['mutatedAminoAcids']}"/></span>Mutated Amino Acids</th>
-                                                            <td><c:choose><c:when test="${not empty lz.mutatedAminoAcids}"><c:out value="${lz.mutatedAminoAcids}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="mutatedAminoAcids" label="Mutated Amino Acids" updates="${lzFieldUpdates['mutatedAminoAcids']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.mutatedAminoAcids}"><c:out value="${lz.mutatedAminoAcids}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="mutatedAminoAcids" label="Mutated Amino Acids" updates="${lzFieldUpdates['mutatedAminoAcids']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="mutatedAminoAcids" label="Mutated Amino Acids"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['mutatedAminoAcidsHgvs']}"/></span>Mutated Amino Acids (HGVS)</th>
-                                                            <td><c:choose><c:when test="${not empty lz.mutatedAminoAcidsHgvs}"><c:out value="${lz.mutatedAminoAcidsHgvs}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="mutatedAminoAcidsHgvs" label="Mutated Amino Acids (HGVS)" updates="${lzFieldUpdates['mutatedAminoAcidsHgvs']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.mutatedAminoAcidsHgvs}"><c:out value="${lz.mutatedAminoAcidsHgvs}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="mutatedAminoAcidsHgvs" label="Mutated Amino Acids (HGVS)" updates="${lzFieldUpdates['mutatedAminoAcidsHgvs']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="mutatedAminoAcidsHgvs" label="Mutated Amino Acids (HGVS)"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${lzFieldStatus['additionalInfo']}"/></span>Additional Info</th>
-                                                            <td><c:choose><c:when test="${not empty lz.additionalInfo}"><c:out value="${lz.additionalInfo}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="additionalInfo" label="Additional Info" updates="${lzFieldUpdates['additionalInfo']}" scope="${lzScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty lz.additionalInfo}"><c:out value="${lz.additionalInfo}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="additionalInfo" label="Additional Info" updates="${lzFieldUpdates['additionalInfo']}" scope="${lzScope}"/><z:zirc-field-comments recId="${lzRecId}" scope="field" fieldName="additionalInfo" label="Additional Info"/></td></tr>
                                                     </tbody>
                                                 </table>
                                             </z:section>
@@ -351,7 +447,7 @@
                                 </c:choose>
                             </z:section>
 
-                            <z:section title="Genotyping Assays" prependedText="${gaBadge}" cssClass="ml-4" sectionID="mutation-${loop.count}-genotyping-assays">
+                            <z:section title="Genotyping Assays" prependedText="${gaBadge}" appendedText="${gaApproval}" cssClass="ml-4" sectionID="mutation-${loop.count}-genotyping-assays">
                                 <c:choose>
                                     <c:when test="${empty m.genotypingAssays}">
                                         <p class="text-muted">No genotyping assays recorded.</p>
@@ -361,57 +457,58 @@
                                             <c:set var="gaFieldStatus" value="${assayFieldStatus[ga.id]}"/>
                                             <c:set var="gaFieldUpdates" value="${assayFieldUpdates[ga.id]}"/>
                                             <c:set var="gaScope" value="ga${ga.id}"/>
+                                            <c:set var="gaRecId" value="ZIRC-GA-${ga.id}"/>
                                             <z:section title="Genotyping Assay ${galoop.count}" cssClass="ml-4">
                                                 <table class="table table-borderless w-auto">
                                                     <tbody>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['assayType']}"/></span>Assay Type</th>
-                                                            <td><c:choose><c:when test="${not empty ga.assayType}"><c:out value="${ga.assayType}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="assayType" label="Assay Type" updates="${gaFieldUpdates['assayType']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.assayType}"><c:out value="${ga.assayType}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="assayType" label="Assay Type" updates="${gaFieldUpdates['assayType']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="assayType" label="Assay Type"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['forwardPrimer']}"/></span>Forward Primer</th>
-                                                            <td><c:choose><c:when test="${not empty ga.forwardPrimer}"><c:out value="${ga.forwardPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="forwardPrimer" label="Forward Primer" updates="${gaFieldUpdates['forwardPrimer']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.forwardPrimer}"><c:out value="${ga.forwardPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="forwardPrimer" label="Forward Primer" updates="${gaFieldUpdates['forwardPrimer']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="forwardPrimer" label="Forward Primer"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['reversePrimer']}"/></span>Reverse Primer</th>
-                                                            <td><c:choose><c:when test="${not empty ga.reversePrimer}"><c:out value="${ga.reversePrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="reversePrimer" label="Reverse Primer" updates="${gaFieldUpdates['reversePrimer']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.reversePrimer}"><c:out value="${ga.reversePrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="reversePrimer" label="Reverse Primer" updates="${gaFieldUpdates['reversePrimer']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="reversePrimer" label="Reverse Primer"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['expectedWtPcr']}"/></span>Expected WT PCR</th>
-                                                            <td><c:choose><c:when test="${not empty ga.expectedWtPcr}"><c:out value="${ga.expectedWtPcr}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="expectedWtPcr" label="Expected WT PCR" updates="${gaFieldUpdates['expectedWtPcr']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.expectedWtPcr}"><c:out value="${ga.expectedWtPcr}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="expectedWtPcr" label="Expected WT PCR" updates="${gaFieldUpdates['expectedWtPcr']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="expectedWtPcr" label="Expected WT PCR"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['expectedMutPcr']}"/></span>Expected Mut PCR</th>
-                                                            <td><c:choose><c:when test="${not empty ga.expectedMutPcr}"><c:out value="${ga.expectedMutPcr}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="expectedMutPcr" label="Expected Mut PCR" updates="${gaFieldUpdates['expectedMutPcr']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.expectedMutPcr}"><c:out value="${ga.expectedMutPcr}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="expectedMutPcr" label="Expected Mut PCR" updates="${gaFieldUpdates['expectedMutPcr']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="expectedMutPcr" label="Expected Mut PCR"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['restrictionEnzymeName']}"/></span>Restriction Enzyme Name</th>
-                                                            <td><c:choose><c:when test="${not empty ga.restrictionEnzymeName}"><c:out value="${ga.restrictionEnzymeName}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="restrictionEnzymeName" label="Restriction Enzyme Name" updates="${gaFieldUpdates['restrictionEnzymeName']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.restrictionEnzymeName}"><c:out value="${ga.restrictionEnzymeName}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="restrictionEnzymeName" label="Restriction Enzyme Name" updates="${gaFieldUpdates['restrictionEnzymeName']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="restrictionEnzymeName" label="Restriction Enzyme Name"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['restrictionEnzymeCatalog']}"/></span>Restriction Enzyme Catalog</th>
-                                                            <td><c:choose><c:when test="${not empty ga.restrictionEnzymeCatalog}"><c:out value="${ga.restrictionEnzymeCatalog}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="restrictionEnzymeCatalog" label="Restriction Enzyme Catalog" updates="${gaFieldUpdates['restrictionEnzymeCatalog']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.restrictionEnzymeCatalog}"><c:out value="${ga.restrictionEnzymeCatalog}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="restrictionEnzymeCatalog" label="Restriction Enzyme Catalog" updates="${gaFieldUpdates['restrictionEnzymeCatalog']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="restrictionEnzymeCatalog" label="Restriction Enzyme Catalog"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['enzymeCleaves']}"/></span>Enzyme Cleaves</th>
-                                                            <td><c:choose><c:when test="${not empty ga.enzymeCleaves}"><c:forEach items="${ga.enzymeCleaves}" var="ec" varStatus="ecloop"><c:if test="${!ecloop.first}">, </c:if><c:out value="${ec}"/></c:forEach></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="enzymeCleaves" label="Enzyme Cleaves" updates="${gaFieldUpdates['enzymeCleaves']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.enzymeCleaves}"><c:forEach items="${ga.enzymeCleaves}" var="ec" varStatus="ecloop"><c:if test="${!ecloop.first}">, </c:if><c:out value="${ec}"/></c:forEach></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="enzymeCleaves" label="Enzyme Cleaves" updates="${gaFieldUpdates['enzymeCleaves']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="enzymeCleaves" label="Enzyme Cleaves"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['expectedWtDigest']}"/></span>Expected WT Digest</th>
-                                                            <td><c:choose><c:when test="${not empty ga.expectedWtDigest}"><c:out value="${ga.expectedWtDigest}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="expectedWtDigest" label="Expected WT Digest" updates="${gaFieldUpdates['expectedWtDigest']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.expectedWtDigest}"><c:out value="${ga.expectedWtDigest}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="expectedWtDigest" label="Expected WT Digest" updates="${gaFieldUpdates['expectedWtDigest']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="expectedWtDigest" label="Expected WT Digest"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['expectedMutDigest']}"/></span>Expected Mut Digest</th>
-                                                            <td><c:choose><c:when test="${not empty ga.expectedMutDigest}"><c:out value="${ga.expectedMutDigest}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="expectedMutDigest" label="Expected Mut Digest" updates="${gaFieldUpdates['expectedMutDigest']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.expectedMutDigest}"><c:out value="${ga.expectedMutDigest}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="expectedMutDigest" label="Expected Mut Digest" updates="${gaFieldUpdates['expectedMutDigest']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="expectedMutDigest" label="Expected Mut Digest"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['sequencingPrimer']}"/></span>Sequencing Primer</th>
-                                                            <td><c:choose><c:when test="${not empty ga.sequencingPrimer}"><c:out value="${ga.sequencingPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sequencingPrimer" label="Sequencing Primer" updates="${gaFieldUpdates['sequencingPrimer']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.sequencingPrimer}"><c:out value="${ga.sequencingPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sequencingPrimer" label="Sequencing Primer" updates="${gaFieldUpdates['sequencingPrimer']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="sequencingPrimer" label="Sequencing Primer"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['dcapsMismatchPrimer']}"/></span>dCAPS Mismatch Primer</th>
-                                                            <td><c:choose><c:when test="${not empty ga.dcapsMismatchPrimer}"><c:out value="${ga.dcapsMismatchPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="dcapsMismatchPrimer" label="dCAPS Mismatch Primer" updates="${gaFieldUpdates['dcapsMismatchPrimer']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.dcapsMismatchPrimer}"><c:out value="${ga.dcapsMismatchPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="dcapsMismatchPrimer" label="dCAPS Mismatch Primer" updates="${gaFieldUpdates['dcapsMismatchPrimer']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="dcapsMismatchPrimer" label="dCAPS Mismatch Primer"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['wtSpecificPrimer']}"/></span>WT Specific Primer</th>
-                                                            <td><c:choose><c:when test="${not empty ga.wtSpecificPrimer}"><c:out value="${ga.wtSpecificPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="wtSpecificPrimer" label="WT Specific Primer" updates="${gaFieldUpdates['wtSpecificPrimer']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.wtSpecificPrimer}"><c:out value="${ga.wtSpecificPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="wtSpecificPrimer" label="WT Specific Primer" updates="${gaFieldUpdates['wtSpecificPrimer']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="wtSpecificPrimer" label="WT Specific Primer"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['mutSpecificPrimer']}"/></span>Mut Specific Primer</th>
-                                                            <td><c:choose><c:when test="${not empty ga.mutSpecificPrimer}"><c:out value="${ga.mutSpecificPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="mutSpecificPrimer" label="Mut Specific Primer" updates="${gaFieldUpdates['mutSpecificPrimer']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.mutSpecificPrimer}"><c:out value="${ga.mutSpecificPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="mutSpecificPrimer" label="Mut Specific Primer" updates="${gaFieldUpdates['mutSpecificPrimer']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="mutSpecificPrimer" label="Mut Specific Primer"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['commonPrimer']}"/></span>Common Primer</th>
-                                                            <td><c:choose><c:when test="${not empty ga.commonPrimer}"><c:out value="${ga.commonPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="commonPrimer" label="Common Primer" updates="${gaFieldUpdates['commonPrimer']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.commonPrimer}"><c:out value="${ga.commonPrimer}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="commonPrimer" label="Common Primer" updates="${gaFieldUpdates['commonPrimer']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="commonPrimer" label="Common Primer"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['kaspGenomicSequence']}"/></span>KASP Genomic Sequence</th>
-                                                            <td><c:choose><c:when test="${not empty ga.kaspGenomicSequence}"><c:out value="${ga.kaspGenomicSequence}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="kaspGenomicSequence" label="KASP Genomic Sequence" updates="${gaFieldUpdates['kaspGenomicSequence']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.kaspGenomicSequence}"><c:out value="${ga.kaspGenomicSequence}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="kaspGenomicSequence" label="KASP Genomic Sequence" updates="${gaFieldUpdates['kaspGenomicSequence']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="kaspGenomicSequence" label="KASP Genomic Sequence"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['sslpMarkerName']}"/></span>SSLP Marker Name</th>
-                                                            <td><c:choose><c:when test="${not empty ga.sslpMarkerName}"><c:out value="${ga.sslpMarkerName}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpMarkerName" label="SSLP Marker Name" updates="${gaFieldUpdates['sslpMarkerName']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.sslpMarkerName}"><c:out value="${ga.sslpMarkerName}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpMarkerName" label="SSLP Marker Name" updates="${gaFieldUpdates['sslpMarkerName']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="sslpMarkerName" label="SSLP Marker Name"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['sslpDistance']}"/></span>SSLP Distance</th>
-                                                            <td><c:choose><c:when test="${not empty ga.sslpDistance}"><c:out value="${ga.sslpDistance}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpDistance" label="SSLP Distance" updates="${gaFieldUpdates['sslpDistance']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.sslpDistance}"><c:out value="${ga.sslpDistance}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpDistance" label="SSLP Distance" updates="${gaFieldUpdates['sslpDistance']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="sslpDistance" label="SSLP Distance"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['sslpGenomicLocation']}"/></span>SSLP Genomic Location</th>
-                                                            <td><c:choose><c:when test="${not empty ga.sslpGenomicLocation}"><c:out value="${ga.sslpGenomicLocation}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpGenomicLocation" label="SSLP Genomic Location" updates="${gaFieldUpdates['sslpGenomicLocation']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.sslpGenomicLocation}"><c:out value="${ga.sslpGenomicLocation}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpGenomicLocation" label="SSLP Genomic Location" updates="${gaFieldUpdates['sslpGenomicLocation']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="sslpGenomicLocation" label="SSLP Genomic Location"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['sslpInducedBackground']}"/></span>SSLP Induced Background</th>
-                                                            <td><c:choose><c:when test="${not empty ga.sslpInducedBackground}"><c:out value="${ga.sslpInducedBackground}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpInducedBackground" label="SSLP Induced Background" updates="${gaFieldUpdates['sslpInducedBackground']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.sslpInducedBackground}"><c:out value="${ga.sslpInducedBackground}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpInducedBackground" label="SSLP Induced Background" updates="${gaFieldUpdates['sslpInducedBackground']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="sslpInducedBackground" label="SSLP Induced Background"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['sslpOutcrossedBackground']}"/></span>SSLP Outcrossed Background</th>
-                                                            <td><c:choose><c:when test="${not empty ga.sslpOutcrossedBackground}"><c:out value="${ga.sslpOutcrossedBackground}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpOutcrossedBackground" label="SSLP Outcrossed Background" updates="${gaFieldUpdates['sslpOutcrossedBackground']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.sslpOutcrossedBackground}"><c:out value="${ga.sslpOutcrossedBackground}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpOutcrossedBackground" label="SSLP Outcrossed Background" updates="${gaFieldUpdates['sslpOutcrossedBackground']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="sslpOutcrossedBackground" label="SSLP Outcrossed Background"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['sslpInducedPcr']}"/></span>SSLP Induced PCR</th>
-                                                            <td><c:choose><c:when test="${not empty ga.sslpInducedPcr}"><c:out value="${ga.sslpInducedPcr}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpInducedPcr" label="SSLP Induced PCR" updates="${gaFieldUpdates['sslpInducedPcr']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.sslpInducedPcr}"><c:out value="${ga.sslpInducedPcr}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpInducedPcr" label="SSLP Induced PCR" updates="${gaFieldUpdates['sslpInducedPcr']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="sslpInducedPcr" label="SSLP Induced PCR"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['sslpOutcrossedPcr']}"/></span>SSLP Outcrossed PCR</th>
-                                                            <td><c:choose><c:when test="${not empty ga.sslpOutcrossedPcr}"><c:out value="${ga.sslpOutcrossedPcr}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpOutcrossedPcr" label="SSLP Outcrossed PCR" updates="${gaFieldUpdates['sslpOutcrossedPcr']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.sslpOutcrossedPcr}"><c:out value="${ga.sslpOutcrossedPcr}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="sslpOutcrossedPcr" label="SSLP Outcrossed PCR" updates="${gaFieldUpdates['sslpOutcrossedPcr']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="sslpOutcrossedPcr" label="SSLP Outcrossed PCR"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${gaFieldStatus['additionalInfo']}"/></span>Additional Info</th>
-                                                            <td><c:choose><c:when test="${not empty ga.additionalInfo}"><c:out value="${ga.additionalInfo}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="additionalInfo" label="Additional Info" updates="${gaFieldUpdates['additionalInfo']}" scope="${gaScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ga.additionalInfo}"><c:out value="${ga.additionalInfo}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="additionalInfo" label="Additional Info" updates="${gaFieldUpdates['additionalInfo']}" scope="${gaScope}"/><z:zirc-field-comments recId="${gaRecId}" scope="field" fieldName="additionalInfo" label="Additional Info"/></td></tr>
                                                     </tbody>
                                                 </table>
                                             </z:section>
@@ -420,7 +517,7 @@
                                 </c:choose>
                             </z:section>
 
-                            <z:section title="Phenotypes" prependedText="${phenoBadge}" cssClass="ml-4" sectionID="mutation-${loop.count}-phenotypes">
+                            <z:section title="Phenotypes" prependedText="${phenoBadge}" appendedText="${phenoApproval}" cssClass="ml-4" sectionID="mutation-${loop.count}-phenotypes">
                                 <c:choose>
                                     <c:when test="${empty m.phenotypes}">
                                         <p class="text-muted">No phenotypes recorded.</p>
@@ -430,29 +527,30 @@
                                             <c:set var="phFieldStatus" value="${phenotypeFieldStatus[ph.id]}"/>
                                             <c:set var="phFieldUpdates" value="${phenotypeFieldUpdates[ph.id]}"/>
                                             <c:set var="phScope" value="phen${ph.id}"/>
+                                            <c:set var="phRecId" value="ZIRC-PHEN-${ph.id}"/>
                                             <z:section title="Phenotype ${phloop.count}" cssClass="ml-4">
                                                 <table class="table table-borderless w-auto">
                                                     <tbody>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${phFieldStatus['description']}"/></span>Description</th>
-                                                            <td><c:choose><c:when test="${not empty ph.description}"><c:out value="${ph.description}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="description" label="Description" updates="${phFieldUpdates['description']}" scope="${phScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ph.description}"><c:out value="${ph.description}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="description" label="Description" updates="${phFieldUpdates['description']}" scope="${phScope}"/><z:zirc-field-comments recId="${phRecId}" scope="field" fieldName="description" label="Description"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${phFieldStatus['hpfStart']}"/></span>HPF Start</th>
-                                                            <td><c:choose><c:when test="${not empty ph.hpfStart}">${ph.hpfStart}</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="hpfStart" label="HPF Start" updates="${phFieldUpdates['hpfStart']}" scope="${phScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ph.hpfStart}">${ph.hpfStart}</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="hpfStart" label="HPF Start" updates="${phFieldUpdates['hpfStart']}" scope="${phScope}"/><z:zirc-field-comments recId="${phRecId}" scope="field" fieldName="hpfStart" label="HPF Start"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${phFieldStatus['hpfEnd']}"/></span>HPF End</th>
-                                                            <td><c:choose><c:when test="${not empty ph.hpfEnd}">${ph.hpfEnd}</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="hpfEnd" label="HPF End" updates="${phFieldUpdates['hpfEnd']}" scope="${phScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ph.hpfEnd}">${ph.hpfEnd}</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="hpfEnd" label="HPF End" updates="${phFieldUpdates['hpfEnd']}" scope="${phScope}"/><z:zirc-field-comments recId="${phRecId}" scope="field" fieldName="hpfEnd" label="HPF End"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${phFieldStatus['stage']}"/></span>Stage</th>
-                                                            <td><c:choose><c:when test="${not empty ph.stage}"><c:out value="${ph.stage}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="stage" label="Stage" updates="${phFieldUpdates['stage']}" scope="${phScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ph.stage}"><c:out value="${ph.stage}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="stage" label="Stage" updates="${phFieldUpdates['stage']}" scope="${phScope}"/><z:zirc-field-comments recId="${phRecId}" scope="field" fieldName="stage" label="Stage"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${phFieldStatus['zfinImagePermission']}"/></span>ZFIN Image Permission</th>
-                                                            <td><c:choose><c:when test="${ph.zfinImagePermission == true}">Yes</c:when><c:when test="${ph.zfinImagePermission == false}">No</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="zfinImagePermission" label="ZFIN Image Permission" updates="${phFieldUpdates['zfinImagePermission']}" scope="${phScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${ph.zfinImagePermission == true}">Yes</c:when><c:when test="${ph.zfinImagePermission == false}">No</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="zfinImagePermission" label="ZFIN Image Permission" updates="${phFieldUpdates['zfinImagePermission']}" scope="${phScope}"/><z:zirc-field-comments recId="${phRecId}" scope="field" fieldName="zfinImagePermission" label="ZFIN Image Permission"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${phFieldStatus['zircImagePermission']}"/></span>ZIRC Image Permission</th>
-                                                            <td><c:choose><c:when test="${ph.zircImagePermission == true}">Yes</c:when><c:when test="${ph.zircImagePermission == false}">No</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="zircImagePermission" label="ZIRC Image Permission" updates="${phFieldUpdates['zircImagePermission']}" scope="${phScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${ph.zircImagePermission == true}">Yes</c:when><c:when test="${ph.zircImagePermission == false}">No</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="zircImagePermission" label="ZIRC Image Permission" updates="${phFieldUpdates['zircImagePermission']}" scope="${phScope}"/><z:zirc-field-comments recId="${phRecId}" scope="field" fieldName="zircImagePermission" label="ZIRC Image Permission"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${phFieldStatus['nonMendelianPercentage']}"/></span>Non-Mendelian Percentage</th>
-                                                            <td><c:choose><c:when test="${not empty ph.nonMendelianPercentage}">${ph.nonMendelianPercentage}</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="nonMendelianPercentage" label="Non-Mendelian Percentage" updates="${phFieldUpdates['nonMendelianPercentage']}" scope="${phScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ph.nonMendelianPercentage}">${ph.nonMendelianPercentage}</c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="nonMendelianPercentage" label="Non-Mendelian Percentage" updates="${phFieldUpdates['nonMendelianPercentage']}" scope="${phScope}"/><z:zirc-field-comments recId="${phRecId}" scope="field" fieldName="nonMendelianPercentage" label="Non-Mendelian Percentage"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${phFieldStatus['nonMendelianComment']}"/></span>Non-Mendelian Comment</th>
-                                                            <td><c:choose><c:when test="${not empty ph.nonMendelianComment}"><c:out value="${ph.nonMendelianComment}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="nonMendelianComment" label="Non-Mendelian Comment" updates="${phFieldUpdates['nonMendelianComment']}" scope="${phScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ph.nonMendelianComment}"><c:out value="${ph.nonMendelianComment}"/></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="nonMendelianComment" label="Non-Mendelian Comment" updates="${phFieldUpdates['nonMendelianComment']}" scope="${phScope}"/><z:zirc-field-comments recId="${phRecId}" scope="field" fieldName="nonMendelianComment" label="Non-Mendelian Comment"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${phFieldStatus['segregation']}"/></span>Segregation</th>
-                                                            <td><c:choose><c:when test="${not empty ph.segregation}"><c:forEach items="${ph.segregation}" var="sg" varStatus="sgloop"><c:if test="${!sgloop.first}">, </c:if><c:out value="${sg}"/></c:forEach></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="segregation" label="Segregation" updates="${phFieldUpdates['segregation']}" scope="${phScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ph.segregation}"><c:forEach items="${ph.segregation}" var="sg" varStatus="sgloop"><c:if test="${!sgloop.first}">, </c:if><c:out value="${sg}"/></c:forEach></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="segregation" label="Segregation" updates="${phFieldUpdates['segregation']}" scope="${phScope}"/><z:zirc-field-comments recId="${phRecId}" scope="field" fieldName="segregation" label="Segregation"/></td></tr>
                                                         <tr><th><span class="status-slot"><z:zirc-status-badge status="${phFieldStatus['type']}"/></span>Type</th>
-                                                            <td><c:choose><c:when test="${not empty ph.type}"><c:forEach items="${ph.type}" var="t" varStatus="tloop"><c:if test="${!tloop.first}">, </c:if><c:out value="${t}"/></c:forEach></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="type" label="Type" updates="${phFieldUpdates['type']}" scope="${phScope}"/></td></tr>
+                                                            <td><c:choose><c:when test="${not empty ph.type}"><c:forEach items="${ph.type}" var="t" varStatus="tloop"><c:if test="${!tloop.first}">, </c:if><c:out value="${t}"/></c:forEach></c:when><c:otherwise><span class="text-muted">&mdash;</span></c:otherwise></c:choose><z:zirc-field-history fieldName="type" label="Type" updates="${phFieldUpdates['type']}" scope="${phScope}"/><z:zirc-field-comments recId="${phRecId}" scope="field" fieldName="type" label="Type"/></td></tr>
                                                     </tbody>
                                                 </table>
                                             </z:section>
@@ -461,7 +559,7 @@
                                 </c:choose>
                             </z:section>
 
-                            <z:section title="Lethality" prependedText="${lethalityBadge}" cssClass="ml-4" sectionID="mutation-${loop.count}-lethality">
+                            <z:section title="Lethality" prependedText="${lethalityBadge}" appendedText="${lethalityApproval}" cssClass="ml-4" sectionID="mutation-${loop.count}-lethality">
                                 <table class="table table-borderless w-auto">
                                     <tbody>
                                         <tr>
@@ -472,7 +570,7 @@
                                                     <c:when test="${m.homozygousLethal == false}">No</c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="homozygousLethal" label="Homozygous Lethal" updates="${mFieldUpdates['homozygousLethal']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="homozygousLethal" label="Homozygous Lethal" updates="${mFieldUpdates['homozygousLethal']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="homozygousLethal" label="Homozygous Lethal"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -482,7 +580,7 @@
                                                     <c:when test="${not empty m.lethalityStageTypical}"><c:out value="${m.lethalityStageTypical}"/></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="lethalityStageTypical" label="Lethality Stage Typical" updates="${mFieldUpdates['lethalityStageTypical']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="lethalityStageTypical" label="Lethality Stage Typical" updates="${mFieldUpdates['lethalityStageTypical']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="lethalityStageTypical" label="Lethality Stage Typical"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -492,7 +590,7 @@
                                                     <c:when test="${not empty m.lethalitySpecificTimepoint}"><c:out value="${m.lethalitySpecificTimepoint}"/></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="lethalitySpecificTimepoint" label="Lethality Specific Timepoint" updates="${mFieldUpdates['lethalitySpecificTimepoint']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="lethalitySpecificTimepoint" label="Lethality Specific Timepoint" updates="${mFieldUpdates['lethalitySpecificTimepoint']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="lethalitySpecificTimepoint" label="Lethality Specific Timepoint"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -502,8 +600,8 @@
                                                     <c:when test="${not empty m.lethalityWindowStart or not empty m.lethalityWindowEnd}"><c:out value="${m.lethalityWindowStart}"/> &ndash; <c:out value="${m.lethalityWindowEnd}"/></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="lethalityWindowStart" label="Lethality Window Start" updates="${mFieldUpdates['lethalityWindowStart']}" scope="${mScope}"/>
-                                                <z:zirc-field-history fieldName="lethalityWindowEnd" label="Lethality Window End" updates="${mFieldUpdates['lethalityWindowEnd']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="lethalityWindowStart" label="Lethality Window Start" updates="${mFieldUpdates['lethalityWindowStart']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="lethalityWindowStart" label="Lethality Window Start"/>
+                                                <z:zirc-field-history fieldName="lethalityWindowEnd" label="Lethality Window End" updates="${mFieldUpdates['lethalityWindowEnd']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="lethalityWindowEnd" label="Lethality Window End"/>
                                             </td>
                                         </tr>
                                         <tr>
@@ -513,14 +611,14 @@
                                                     <c:when test="${not empty m.lethalityAdditionalInfo}"><c:out value="${m.lethalityAdditionalInfo}"/></c:when>
                                                     <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                                 </c:choose>
-                                                <z:zirc-field-history fieldName="lethalityAdditionalInfo" label="Lethality Additional Info" updates="${mFieldUpdates['lethalityAdditionalInfo']}" scope="${mScope}"/>
+                                                <z:zirc-field-history fieldName="lethalityAdditionalInfo" label="Lethality Additional Info" updates="${mFieldUpdates['lethalityAdditionalInfo']}" scope="${mScope}"/><z:zirc-field-comments recId="${mRecId}" scope="field" fieldName="lethalityAdditionalInfo" label="Lethality Additional Info"/>
                                             </td>
                                         </tr>
                                     </tbody>
                                 </table>
                             </z:section>
 
-                            <z:section title="Publications" prependedText="${pubsBadge}" cssClass="ml-4" sectionID="mutation-${loop.count}-publications">
+                            <z:section title="Publications" prependedText="${pubsBadge}" appendedText="${pubsApproval}" cssClass="ml-4" sectionID="mutation-${loop.count}-publications">
                                 <c:choose>
                                     <c:when test="${empty m.publications}">
                                         <p class="text-muted">No publications recorded.</p>
@@ -538,8 +636,9 @@
             </c:choose>
         </z:section>
 
-        <c:set var="linkedBadge"><z:zirc-status-badge status="${sectionStatus['Linked Features']}"/><z:zirc-section-history key="linked-features" label="Linked Features" updates="${sectionUpdates['Linked Features']}"/></c:set>
-        <z:section title="${LINKED_FEATURES}" prependedText="${linkedBadge}">
+        <c:set var="linkedBadge"><z:zirc-status-badge status="${sectionStatus['Linked Features']}"/><z:zirc-section-history key="linked-features" label="Linked Features" updates="${sectionUpdates['Linked Features']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="section" sectionName="linked-features" label="Linked Features"/></c:set>
+        <c:set var="linkedApproval"><z:zirc-section-approval recId="${submission.zdbID}" sectionName="linked-features" approved="${sectionApprovals[submission.zdbID.concat('|linked-features')]}" enabled="${(sectionStatus['Linked Features'] != null) and (sectionStatus['Linked Features'].name() == 'COMPLETE' or sectionStatus['Linked Features'].name() == 'APPROVED')}"/></c:set>
+        <z:section title="${LINKED_FEATURES}" prependedText="${linkedBadge}" appendedText="${linkedApproval}">
             <c:choose>
                 <c:when test="${empty submission.linkedFeatures}">
                     <p class="text-muted">No linked features.</p>
@@ -560,20 +659,21 @@
                                 <c:set var="lfKey" value="${lf.mutationA.id}-${lf.mutationB.id}"/>
                                 <c:set var="lfUpdates" value="${linkedFeatureFieldUpdates[lfKey]}"/>
                                 <c:set var="lfScope" value="lf${lfKey}"/>
+                                <c:set var="lfRecId" value="ZIRC-LF-${lfKey}"/>
                                 <tr>
                                     <td>
                                         <c:choose>
                                             <c:when test="${not empty lf.mutationA.alleleDesignation}"><c:out value="${lf.mutationA.alleleDesignation}"/></c:when>
                                             <c:otherwise>#${lf.mutationA.sortOrder}</c:otherwise>
                                         </c:choose>
-                                        <z:zirc-field-history fieldName="mutationA" label="Mutation A" updates="${lfUpdates['mutationA']}" scope="${lfScope}"/>
+                                        <z:zirc-field-history fieldName="mutationA" label="Mutation A" updates="${lfUpdates['mutationA']}" scope="${lfScope}"/><z:zirc-field-comments recId="${lfRecId}" scope="field" fieldName="mutationA" label="Mutation A"/>
                                     </td>
                                     <td>
                                         <c:choose>
                                             <c:when test="${not empty lf.mutationB.alleleDesignation}"><c:out value="${lf.mutationB.alleleDesignation}"/></c:when>
                                             <c:otherwise>#${lf.mutationB.sortOrder}</c:otherwise>
                                         </c:choose>
-                                        <z:zirc-field-history fieldName="mutationB" label="Mutation B" updates="${lfUpdates['mutationB']}" scope="${lfScope}"/>
+                                        <z:zirc-field-history fieldName="mutationB" label="Mutation B" updates="${lfUpdates['mutationB']}" scope="${lfScope}"/><z:zirc-field-comments recId="${lfRecId}" scope="field" fieldName="mutationB" label="Mutation B"/>
                                     </td>
                                     <td>
                                         <c:choose>
@@ -581,7 +681,7 @@
                                             <c:when test="${lf.distanceKnown == false}">No</c:when>
                                             <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                         </c:choose>
-                                        <z:zirc-field-history fieldName="distanceKnown" label="Distance Known" updates="${lfUpdates['distanceKnown']}" scope="${lfScope}"/>
+                                        <z:zirc-field-history fieldName="distanceKnown" label="Distance Known" updates="${lfUpdates['distanceKnown']}" scope="${lfScope}"/><z:zirc-field-comments recId="${lfRecId}" scope="field" fieldName="distanceKnown" label="Distance Known"/>
                                     </td>
                                     <td>
                                         <c:choose>
@@ -589,15 +689,15 @@
                                             <c:when test="${not empty lf.distanceMegabases}">${lf.distanceMegabases} Mb</c:when>
                                             <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                         </c:choose>
-                                        <z:zirc-field-history fieldName="distanceCentimorgans" label="Distance (cM)" updates="${lfUpdates['distanceCentimorgans']}" scope="${lfScope}"/>
-                                        <z:zirc-field-history fieldName="distanceMegabases" label="Distance (Mb)" updates="${lfUpdates['distanceMegabases']}" scope="${lfScope}"/>
+                                        <z:zirc-field-history fieldName="distanceCentimorgans" label="Distance (cM)" updates="${lfUpdates['distanceCentimorgans']}" scope="${lfScope}"/><z:zirc-field-comments recId="${lfRecId}" scope="field" fieldName="distanceCentimorgans" label="Distance (cM)"/>
+                                        <z:zirc-field-history fieldName="distanceMegabases" label="Distance (Mb)" updates="${lfUpdates['distanceMegabases']}" scope="${lfScope}"/><z:zirc-field-comments recId="${lfRecId}" scope="field" fieldName="distanceMegabases" label="Distance (Mb)"/>
                                     </td>
                                     <td>
                                         <c:choose>
                                             <c:when test="${not empty lf.additionalInfo}"><c:out value="${lf.additionalInfo}"/></c:when>
                                             <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                                         </c:choose>
-                                        <z:zirc-field-history fieldName="additionalInfo" label="Additional Info" updates="${lfUpdates['additionalInfo']}" scope="${lfScope}"/>
+                                        <z:zirc-field-history fieldName="additionalInfo" label="Additional Info" updates="${lfUpdates['additionalInfo']}" scope="${lfScope}"/><z:zirc-field-comments recId="${lfRecId}" scope="field" fieldName="additionalInfo" label="Additional Info"/>
                                     </td>
                                 </tr>
                             </c:forEach>
@@ -607,8 +707,9 @@
             </c:choose>
         </z:section>
 
-        <c:set var="backgroundBadge"><z:zirc-status-badge status="${sectionStatus['Background']}"/><z:zirc-section-history key="background" label="Background" updates="${sectionUpdates['Background']}"/></c:set>
-        <z:section title="${BACKGROUND}" prependedText="${backgroundBadge}">
+        <c:set var="backgroundBadge"><z:zirc-status-badge status="${sectionStatus['Background']}"/><z:zirc-section-history key="background" label="Background" updates="${sectionUpdates['Background']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="section" sectionName="background" label="Background"/></c:set>
+        <c:set var="backgroundApproval"><z:zirc-section-approval recId="${submission.zdbID}" sectionName="background" approved="${sectionApprovals[submission.zdbID.concat('|background')]}" enabled="${(sectionStatus['Background'] != null) and (sectionStatus['Background'].name() == 'COMPLETE' or sectionStatus['Background'].name() == 'APPROVED')}"/></c:set>
+        <z:section title="${BACKGROUND}" prependedText="${backgroundBadge}" appendedText="${backgroundApproval}">
             <table class="table table-borderless w-auto">
                 <tbody>
                     <tr>
@@ -618,7 +719,7 @@
                                 <c:when test="${not empty submission.maternalBackground}"><c:out value="${submission.maternalBackground}"/></c:when>
                                 <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                             </c:choose>
-                            <z:zirc-field-history fieldName="maternalBackground" label="Maternal Background" updates="${fieldUpdates['maternalBackground']}"/>
+                            <z:zirc-field-history fieldName="maternalBackground" label="Maternal Background" updates="${fieldUpdates['maternalBackground']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="field" fieldName="maternalBackground" label="Maternal Background"/>
                         </td>
                     </tr>
                     <tr>
@@ -628,7 +729,7 @@
                                 <c:when test="${not empty submission.paternalBackground}"><c:out value="${submission.paternalBackground}"/></c:when>
                                 <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                             </c:choose>
-                            <z:zirc-field-history fieldName="paternalBackground" label="Paternal Background" updates="${fieldUpdates['paternalBackground']}"/>
+                            <z:zirc-field-history fieldName="paternalBackground" label="Paternal Background" updates="${fieldUpdates['paternalBackground']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="field" fieldName="paternalBackground" label="Paternal Background"/>
                         </td>
                     </tr>
                     <tr>
@@ -639,7 +740,7 @@
                                 <c:when test="${submission.backgroundChangeable == false}">No</c:when>
                                 <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                             </c:choose>
-                            <z:zirc-field-history fieldName="backgroundChangeable" label="Background Changeable" updates="${fieldUpdates['backgroundChangeable']}"/>
+                            <z:zirc-field-history fieldName="backgroundChangeable" label="Background Changeable" updates="${fieldUpdates['backgroundChangeable']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="field" fieldName="backgroundChangeable" label="Background Changeable"/>
                         </td>
                     </tr>
                     <tr>
@@ -649,15 +750,16 @@
                                 <c:when test="${not empty submission.backgroundChangeConcerns}"><c:out value="${submission.backgroundChangeConcerns}"/></c:when>
                                 <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                             </c:choose>
-                            <z:zirc-field-history fieldName="backgroundChangeConcerns" label="Concerns" updates="${fieldUpdates['backgroundChangeConcerns']}"/>
+                            <z:zirc-field-history fieldName="backgroundChangeConcerns" label="Concerns" updates="${fieldUpdates['backgroundChangeConcerns']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="field" fieldName="backgroundChangeConcerns" label="Concerns"/>
                         </td>
                     </tr>
                 </tbody>
             </table>
         </z:section>
 
-        <c:set var="additionalBadge"><z:zirc-status-badge status="${sectionStatus['Additional Info']}"/><z:zirc-section-history key="additional-info" label="Additional Info" updates="${sectionUpdates['Additional Info']}"/></c:set>
-        <z:section title="${ADDITIONAL}" prependedText="${additionalBadge}">
+        <c:set var="additionalBadge"><z:zirc-status-badge status="${sectionStatus['Additional Info']}"/><z:zirc-section-history key="additional-info" label="Additional Info" updates="${sectionUpdates['Additional Info']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="section" sectionName="additional-info" label="Additional Info"/></c:set>
+        <c:set var="additionalApproval"><z:zirc-section-approval recId="${submission.zdbID}" sectionName="additional-info" approved="${sectionApprovals[submission.zdbID.concat('|additional-info')]}" enabled="${(sectionStatus['Additional Info'] != null) and (sectionStatus['Additional Info'].name() == 'COMPLETE' or sectionStatus['Additional Info'].name() == 'APPROVED')}"/></c:set>
+        <z:section title="${ADDITIONAL}" prependedText="${additionalBadge}" appendedText="${additionalApproval}">
             <table class="table table-borderless w-auto">
                 <tbody>
                     <tr>
@@ -667,7 +769,7 @@
                                 <c:when test="${not empty submission.additionalInfo}"><c:out value="${submission.additionalInfo}"/></c:when>
                                 <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                             </c:choose>
-                            <z:zirc-field-history fieldName="additionalInfo" label="Additional Info" updates="${fieldUpdates['additionalInfo']}"/>
+                            <z:zirc-field-history fieldName="additionalInfo" label="Additional Info" updates="${fieldUpdates['additionalInfo']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="field" fieldName="additionalInfo" label="Additional Info"/>
                         </td>
                     </tr>
                     <tr>
@@ -677,12 +779,51 @@
                                 <c:when test="${not empty submission.unreportedFeaturesDetails}"><c:out value="${submission.unreportedFeaturesDetails}"/></c:when>
                                 <c:otherwise><span class="text-muted">&mdash;</span></c:otherwise>
                             </c:choose>
-                            <z:zirc-field-history fieldName="unreportedFeaturesDetails" label="Unreported Features Details" updates="${fieldUpdates['unreportedFeaturesDetails']}"/>
+                            <z:zirc-field-history fieldName="unreportedFeaturesDetails" label="Unreported Features Details" updates="${fieldUpdates['unreportedFeaturesDetails']}"/><z:zirc-field-comments recId="${submission.zdbID}" scope="field" fieldName="unreportedFeaturesDetails" label="Unreported Features Details"/>
                         </td>
                     </tr>
                 </tbody>
             </table>
         </z:section>
+
+        <%-- Shared comments modal (one per page). The trigger anchors that
+             open it carry the target context as data-* attributes; the
+             JS at the bottom of the page reads them on show, fetches the
+             thread via AJAX, and rebinds the form's submit handler to
+             POST against the same target.
+             No `fade` — we open/close manually so we don't depend on
+             Bootstrap's transition end firing reliably for this modal. --%>
+        <div class="modal" id="zircCommentsModal" tabindex="-1" role="dialog" aria-hidden="true">
+            <div class="modal-dialog modal-lg" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="zirc-comments-title">Comments</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <form id="zirc-comments-form" class="mb-3">
+                            <div class="form-group mb-2">
+                                <textarea id="zirc-comments-input" class="form-control" rows="3"
+                                          placeholder="Add a comment&hellip;" required></textarea>
+                            </div>
+                            <div class="d-flex justify-content-between align-items-center">
+                                <div id="zirc-comments-error" class="text-danger small" style="display:none;"></div>
+                                <button type="submit" class="btn btn-sm btn-primary ml-auto">Post</button>
+                            </div>
+                        </form>
+                        <hr/>
+                        <div id="zirc-comments-list">
+                            <p class="text-muted small">Loading&hellip;</p>
+                        </div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
 
         <%-- Modal for adding a submitter via person-name autocomplete. --%>
         <div class="modal fade" id="addSubmitterModal" tabindex="-1" role="dialog" aria-hidden="true">
@@ -696,10 +837,10 @@
                     </div>
                     <div class="modal-body">
                         <label for="add-submitter-person-input" class="form-label">Search for a person by name</label>
-                        <input type="text" id="add-submitter-person-input" class="form-control" autocomplete="off" placeholder="Start typing a name…"/>
+                        <input type="text" id="add-submitter-person-input" class="form-control" autocomplete="off" placeholder="Start typing a name&hellip;"/>
                         <div class="form-text text-muted small mt-1">Pick a name from the dropdown to add.</div>
                         <div id="add-submitter-error" class="text-danger small mt-2" style="display:none;"></div>
-                        <div id="add-submitter-progress" class="text-muted small mt-2" style="display:none;">Adding…</div>
+                        <div id="add-submitter-progress" class="text-muted small mt-2" style="display:none;">Adding&hellip;</div>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
@@ -810,6 +951,246 @@
                     initAutocomplete();
                     jQuery('#add-submitter-person-input').trigger('focus');
                 });
+
+            // ─── Per-field / per-section comments modal ───────────────────
+            // Trigger anchors (.zirc-comments-trigger) carry the thread
+            // target as data-* attributes; the modal is shared. We open
+            // it via JS instead of data-toggle so the target context
+            // travels along on the event.
+            // Reparent to <body> so position:fixed is relative to the
+            // viewport, not whichever transformed ancestor we'd otherwise
+            // be trapped in (which is what makes the modal disappear
+            // behind the backdrop with only the grey overlay visible).
+            var $cmodal  = jQuery('#zircCommentsModal').appendTo('body');
+            // Manual open/close — we found Bootstrap's .modal('show')
+            // intermittently bails before adding .show on this modal
+            // (display:block was set, .show class never got added → grey
+            // backdrop with no dialog). Hand-rolling the four bits of
+            // state Bootstrap juggles works around it.
+            function openCommentsModal() {
+                $cmodal.css('display', 'block').addClass('show');
+                jQuery('body').addClass('modal-open');
+                if (jQuery('.zirc-comments-backdrop').length === 0) {
+                    jQuery('<div class="modal-backdrop show zirc-comments-backdrop"></div>')
+                        .appendTo('body')
+                        .on('click', closeCommentsModal);
+                }
+            }
+            function closeCommentsModal() {
+                $cmodal.css('display', 'none').removeClass('show');
+                jQuery('.zirc-comments-backdrop').remove();
+                if (jQuery('.modal.show').length === 0) {
+                    jQuery('body').removeClass('modal-open');
+                }
+            }
+            // Wire close on the [data-dismiss="modal"] buttons inside our modal
+            // (we own them; the modal plugin's own delegate doesn't fire when
+            // we open manually).
+            $cmodal.find('[data-dismiss="modal"]').on('click', closeCommentsModal);
+            // Escape key closes too.
+            jQuery(document).on('keydown.zircComments', function (e) {
+                if (e.key === 'Escape' && $cmodal.hasClass('show')) {
+                    closeCommentsModal();
+                }
+            });
+            var $cTitle  = jQuery('#zirc-comments-title');
+            var $cInput  = jQuery('#zirc-comments-input');
+            var $cError  = jQuery('#zirc-comments-error');
+            var $cList   = jQuery('#zirc-comments-list');
+            var $cForm   = jQuery('#zirc-comments-form');
+            var ctx      = {};   // current thread context
+
+            function esc(s) { return jQuery('<div/>').text(s == null ? '' : s).html(); }
+            function fmtWhen(iso) {
+                if (!iso) return '';
+                try {
+                    var d = new Date(iso);
+                    return d.toLocaleString();
+                } catch (e) { return iso; }
+            }
+            function renderComments(rows) {
+                if (!rows || !rows.length) {
+                    $cList.html('<p class="text-muted small">No comments yet. Be the first.</p>');
+                    return;
+                }
+                var html = rows.map(function (r) {
+                    var who = r.authorZdbId
+                        ? '<a href="/action/profile/person/view/' + esc(r.authorZdbId) + '">' + esc(r.author) + '</a>'
+                        : esc(r.author);
+                    return ''
+                        + '<div class="border rounded p-2 mb-2">'
+                        + '  <div class="small text-muted d-flex justify-content-between">'
+                        + '    <span>' + who + '</span>'
+                        + '    <span>' + esc(fmtWhen(r.createdAt)) + '</span>'
+                        + '  </div>'
+                        + '  <div style="white-space:pre-wrap;">' + esc(r.comment) + '</div>'
+                        + '</div>';
+                }).join('');
+                $cList.html(html);
+            }
+            function loadComments() {
+                $cList.html('<p class="text-muted small">Loading&hellip;</p>');
+                var params = {
+                    recId: ctx.recId,
+                    scope: ctx.scope
+                };
+                if (ctx.scope === 'field')   params.fieldName   = ctx.name;
+                if (ctx.scope === 'section') params.sectionName = ctx.name;
+                jQuery.getJSON('/action/zirc/comments', params)
+                    .done(renderComments)
+                    .fail(function (xhr) {
+                        $cList.html('<p class="text-danger small">Failed to load: ' + esc(xhr.statusText) + '</p>');
+                    });
+            }
+
+            // Open the shared modal when any trigger is clicked.
+            jQuery(document).on('click', '.zirc-comments-trigger', function (e) {
+                e.preventDefault();
+                var $t = jQuery(this);
+                ctx = {
+                    recId: $t.data('rec-id'),
+                    scope: $t.data('scope'),
+                    name:  $t.data('scope') === 'field'
+                                ? $t.data('field-name')
+                                : $t.data('section-name'),
+                    label: $t.data('label')
+                };
+                $cTitle.text('Comments \u2014 ' + ctx.label);
+                $cInput.val('');
+                $cError.hide().text('');
+                openCommentsModal();
+                loadComments();
+                $cInput.trigger('focus');
+            });
+
+            $cForm.on('submit', function (e) {
+                e.preventDefault();
+                var text = jQuery.trim($cInput.val());
+                if (!text) { $cInput.trigger('focus'); return; }
+                $cError.hide();
+                var data = {
+                    recId: ctx.recId,
+                    scope: ctx.scope,
+                    comment: text
+                };
+                if (ctx.scope === 'field')   data.fieldName   = ctx.name;
+                if (ctx.scope === 'section') data.sectionName = ctx.name;
+                jQuery.post('/action/zirc/comments', data)
+                    .done(function () {
+                        $cInput.val('');
+                        loadComments();
+                    })
+                    .fail(function (xhr) {
+                        var msg = (xhr.responseJSON && xhr.responseJSON.message) || xhr.statusText;
+                        $cError.text('Failed to post: ' + msg).show();
+                    });
+            });
+
+            // Cmd/Ctrl+Enter posts the comment for quick keyboard flow.
+            $cInput.on('keydown', function (e) {
+                if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+                    e.preventDefault();
+                    $cForm.trigger('submit');
+                }
+            });
+
+            // ─── Per-section "Approved" checkbox ──────────────────────────
+            // Toggling POSTs to /action/zirc/section-approval immediately;
+            // checkbox state is rolled back if the server rejects.
+            // Badge flip helpers. Since the Approved checkbox is only
+            // enabled when the section's underlying status is COMPLETE
+            // (or already APPROVED), un-approving always returns the
+            // badge to COMPLETE — no need to cache base state.
+            function badgeToApproved($badge) {
+                if (!$badge.length) return;
+                $badge.removeClass('badge-success badge-warning badge-danger')
+                      .addClass('badge-primary')
+                      .attr('title', 'Approved')
+                      .text('A');
+            }
+            function badgeToComplete($badge) {
+                if (!$badge.length) return;
+                $badge.removeClass('badge-warning badge-danger badge-primary')
+                      .addClass('badge-success')
+                      .attr('title', 'Complete')
+                      .text('C');
+            }
+
+            // Sync the top-of-page status-overview bar from the current
+            // section-badge classes. Run after every approval toggle so
+            // the bar reflects the live UI without a page reload.
+            function syncStatusBar() {
+                jQuery('.status-overview-bar td.status-cell').each(function () {
+                    var $cell = jQuery(this);
+                    var secId = $cell.data('section-id');
+                    if (!secId) return;
+                    var $badge = jQuery('section#' + secId).children('.heading').find('.badge').first();
+                    $cell.removeClass('status-missing status-in-progress status-complete status-approved');
+                    if (!$badge.length) return;
+                    if      ($badge.hasClass('badge-danger'))  $cell.addClass('status-missing');
+                    else if ($badge.hasClass('badge-warning')) $cell.addClass('status-in-progress');
+                    else if ($badge.hasClass('badge-success')) $cell.addClass('status-complete');
+                    else if ($badge.hasClass('badge-primary')) $cell.addClass('status-approved');
+                });
+            }
+            // For each parent section above $section, recompute "are all
+            // its direct-child sections approved?" and flip its badge.
+            // Continues up until we run out of parent sections, then
+            // also updates the page <h1> overall badge.
+            function propagateApprovalUp($section) {
+                while ($section.length) {
+                    var $parent = $section.parent().closest('section.section');
+                    if (!$parent.length) break;
+                    var $childCBs = $parent.children('section.section')
+                                           .children('.heading')
+                                           .find('.zirc-section-approval');
+                    if ($childCBs.length) {
+                        var allChecked = $childCBs.toArray().every(function (cb) { return cb.checked; });
+                        var $parentBadge = $parent.children('.heading').find('.badge').first();
+                        if (allChecked) badgeToApproved($parentBadge);
+                        else            badgeToComplete($parentBadge);
+                    }
+                    $section = $parent;
+                }
+                // Page header: all top-level section approvals?
+                var $topCBs = jQuery('section.section').filter(function () {
+                    return !jQuery(this).parent().closest('section.section').length;
+                }).children('.heading').find('.zirc-section-approval');
+                if ($topCBs.length) {
+                    var allTop = $topCBs.toArray().every(function (cb) { return cb.checked; });
+                    var $h1Badge = jQuery('h1 > .badge').first();
+                    if (allTop) badgeToApproved($h1Badge);
+                    else        badgeToComplete($h1Badge);
+                }
+            }
+
+            jQuery(document).on('change', '.zirc-section-approval', function () {
+                var $cb = jQuery(this);
+                var approved = $cb.is(':checked');
+                $cb.prop('disabled', true);
+                jQuery.post('/action/zirc/section-approval', {
+                    recId:       $cb.data('rec-id'),
+                    sectionName: $cb.data('section-name'),
+                    approved:    approved
+                })
+                .done(function () {
+                    // Flip THIS section's badge. The checkbox was enabled
+                    // only when its base was COMPLETE (or already
+                    // APPROVED), so it's safe to revert to "C" on uncheck.
+                    var $badge = $cb.closest('.heading').find('.badge').first();
+                    if (approved) badgeToApproved($badge);
+                    else          badgeToComplete($badge);
+                    // Walk up: parent sections roll-up = all-children-approved.
+                    propagateApprovalUp($cb.closest('section.section'));
+                    syncStatusBar();
+                })
+                .always(function () { $cb.prop('disabled', false); })
+                .fail(function (xhr) {
+                    $cb.prop('checked', !approved);
+                    var msg = (xhr.responseJSON && xhr.responseJSON.message) || xhr.statusText;
+                    alert('Failed to save approval: ' + msg);
+                });
+            });
         });
         </script>
 

--- a/home/WEB-INF/tags/layout/zirc-field-comments.tag
+++ b/home/WEB-INF/tags/layout/zirc-field-comments.tag
@@ -1,5 +1,6 @@
 <%@ tag pageEncoding="UTF-8" trimDirectiveWhitespaces="true" %>
 <%@ taglib prefix="c"   uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fn"  uri="http://java.sun.com/jsp/jstl/functions" %>
 <%--
   Trigger icon for the per-field / per-section curator <-> submitter
   comment thread. Clicking opens the shared #zircCommentsModal which
@@ -17,12 +18,21 @@
 <%@ attribute name="sectionName" required="false" rtexprvalue="true" type="java.lang.String" %>
 <%@ attribute name="label"       required="true"  rtexprvalue="true" type="java.lang.String" %>
 
+<%-- HTML-escape every value that lands in an attribute: label can come
+     from submission / mutation names which are curator-entered, so a
+     stray quote or angle bracket must not break the attribute context. --%>
+<c:set var="safeLabel"       value="${fn:escapeXml(label)}"/>
+<c:set var="safeRecId"       value="${fn:escapeXml(recId)}"/>
+<c:set var="safeScope"       value="${fn:escapeXml(scope)}"/>
+<c:set var="safeFieldName"   value="${fn:escapeXml(fieldName)}"/>
+<c:set var="safeSectionName" value="${fn:escapeXml(sectionName)}"/>
+
 <a href="javascript:void(0)" class="ml-2 text-muted field-history-trigger zirc-comments-trigger"
-   title="Comments &mdash; ${label}"
-   data-rec-id="${recId}"
-   data-scope="${scope}"
-   data-field-name="${fieldName}"
-   data-section-name="${sectionName}"
-   data-label="${label}">
+   title="Comments &mdash; ${safeLabel}"
+   data-rec-id="${safeRecId}"
+   data-scope="${safeScope}"
+   data-field-name="${safeFieldName}"
+   data-section-name="${safeSectionName}"
+   data-label="${safeLabel}">
     <i class="far fa-comments"></i>
 </a>

--- a/home/WEB-INF/tags/layout/zirc-field-comments.tag
+++ b/home/WEB-INF/tags/layout/zirc-field-comments.tag
@@ -1,0 +1,28 @@
+<%@ tag pageEncoding="UTF-8" trimDirectiveWhitespaces="true" %>
+<%@ taglib prefix="c"   uri="http://java.sun.com/jsp/jstl/core" %>
+<%--
+  Trigger icon for the per-field / per-section curator <-> submitter
+  comment thread. Clicking opens the shared #zircCommentsModal which
+  reads its target context from this trigger's data-* attributes.
+
+  Used for BOTH scopes: pass scope="field" with fieldName, or
+  scope="section" with sectionName. The label is the human-readable
+  title shown in the modal header.
+--%>
+<%@ attribute name="recId"       required="true"  rtexprvalue="true" type="java.lang.String" %>
+<%@ attribute name="scope"       required="true"  rtexprvalue="true" type="java.lang.String" %>
+<%-- For scope="field" --%>
+<%@ attribute name="fieldName"   required="false" rtexprvalue="true" type="java.lang.String" %>
+<%-- For scope="section" --%>
+<%@ attribute name="sectionName" required="false" rtexprvalue="true" type="java.lang.String" %>
+<%@ attribute name="label"       required="true"  rtexprvalue="true" type="java.lang.String" %>
+
+<a href="javascript:void(0)" class="ml-2 text-muted field-history-trigger zirc-comments-trigger"
+   title="Comments &mdash; ${label}"
+   data-rec-id="${recId}"
+   data-scope="${scope}"
+   data-field-name="${fieldName}"
+   data-section-name="${sectionName}"
+   data-label="${label}">
+    <i class="far fa-comments"></i>
+</a>

--- a/home/WEB-INF/tags/layout/zirc-field-history.tag
+++ b/home/WEB-INF/tags/layout/zirc-field-history.tag
@@ -21,8 +21,9 @@
 <%@ attribute name="scope"     required="false" rtexprvalue="true" type="java.lang.String" %>
 
 <c:if test="${not empty updates}">
-    <c:set var="modalId" value="fieldUpdatesModal-${fieldName}${empty scope ? '' : '-'}${scope}"/>
-    <a href="javascript:void(0)" class="ml-2 text-muted field-history-trigger" title="View change history for ${label}"
+    <c:set var="modalId"   value="fieldUpdatesModal-${fieldName}${empty scope ? '' : '-'}${scope}"/>
+    <c:set var="safeLabel" value="${fn:escapeXml(label)}"/>
+    <a href="javascript:void(0)" class="ml-2 text-muted field-history-trigger" title="View change history for ${safeLabel}"
        data-toggle="modal" data-target="#${modalId}">
         <i class="fas fa-history"></i>
     </a>
@@ -30,7 +31,7 @@
         <div class="modal-dialog modal-lg" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">${label} &mdash; Change History</h5>
+                    <h5 class="modal-title">${safeLabel} &mdash; Change History</h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>

--- a/home/WEB-INF/tags/layout/zirc-section-approval.tag
+++ b/home/WEB-INF/tags/layout/zirc-section-approval.tag
@@ -1,0 +1,26 @@
+<%@ tag pageEncoding="UTF-8" trimDirectiveWhitespaces="true" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%--
+  Curator "Approved" checkbox for a section header. The change handler
+  in line-submission-detail.jsp POSTs the new state to
+  /action/zirc/section-approval; initial checked state is loaded from
+  the sectionApprovals model attribute (keyed "<recId>|<sectionName>").
+--%>
+<%@ attribute name="recId"       required="true"  rtexprvalue="true" type="java.lang.String" %>
+<%@ attribute name="sectionName" required="true"  rtexprvalue="true" type="java.lang.String" %>
+<%@ attribute name="approved"    required="false" rtexprvalue="true" type="java.lang.Boolean" %>
+<%-- Disable the checkbox until every field under this section reads
+     "Complete". Defaults to true (enabled) when omitted. --%>
+<%@ attribute name="enabled"     required="false" rtexprvalue="true" type="java.lang.Boolean" %>
+
+<c:set var="isEnabled" value="${enabled == null or enabled}"/>
+<label class="form-check-inline ml-3 mb-0 small text-muted zirc-section-approval-wrapper${isEnabled ? '' : ' disabled'}"
+       onclick="event.stopPropagation();"
+       title="${isEnabled ? 'Mark this section as approved' : 'All fields under this section must be Complete before it can be approved'}">
+    <input type="checkbox" class="form-check-input zirc-section-approval mr-1"
+           data-rec-id="${recId}"
+           data-section-name="${sectionName}"
+           <c:if test="${approved}">checked="checked"</c:if>
+           <c:if test="${not isEnabled}">disabled="disabled"</c:if>/>
+    Approved
+</label>

--- a/home/WEB-INF/tags/layout/zirc-section-history.tag
+++ b/home/WEB-INF/tags/layout/zirc-section-history.tag
@@ -21,8 +21,9 @@
 <%@ attribute name="scope"   required="false" rtexprvalue="true" type="java.lang.String" %>
 
 <c:if test="${not empty updates}">
-    <c:set var="modalId" value="sectionUpdatesModal-${key}${empty scope ? '' : '-'}${scope}"/>
-    <a href="javascript:void(0)" class="ml-1 text-muted field-history-trigger" title="View change history for ${label}"
+    <c:set var="modalId"  value="sectionUpdatesModal-${key}${empty scope ? '' : '-'}${scope}"/>
+    <c:set var="safeLabel" value="${fn:escapeXml(label)}"/>
+    <a href="javascript:void(0)" class="ml-1 text-muted field-history-trigger" title="View change history for ${safeLabel}"
        data-toggle="modal" data-target="#${modalId}">
         <i class="fas fa-history"></i>
     </a>
@@ -30,7 +31,7 @@
         <div class="modal-dialog modal-xl" role="document">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title">${label} &mdash; Change History</h5>
+                    <h5 class="modal-title">${safeLabel} &mdash; Change History</h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
                     </button>

--- a/home/WEB-INF/web.xml
+++ b/home/WEB-INF/web.xml
@@ -314,6 +314,18 @@
         <session-timeout>-1</session-timeout>
     </session-config>
 
+    <!-- Treat every .jsp file's source bytes AND its rendered output as
+         UTF-8. Without this, JSP defaults to ISO-8859-1, so literal
+         non-ASCII characters in the source (em-dashes, ellipses, etc.)
+         get mojibaked in the browser. -->
+    <jsp-config>
+        <jsp-property-group>
+            <url-pattern>*.jsp</url-pattern>
+            <page-encoding>UTF-8</page-encoding>
+            <default-content-type>text/html;charset=UTF-8</default-content-type>
+        </jsp-property-group>
+    </jsp-config>
+
     <!-- The Usual Welcome File List -->
     <welcome-file-list>
         <welcome-file>index.html</welcome-file>

--- a/source/org/zfin/db/postGmakePostloaddb/1182/migrations/0060-ZFIN-10304-zirc-line-submission-comment.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1182/migrations/0060-ZFIN-10304-zirc-line-submission-comment.sql
@@ -1,0 +1,46 @@
+--liquibase formatted sql
+
+-- Curator/submitter conversation thread attached to a line submission's
+-- fields and sections. Each row is one comment. The (rec_id, scope,
+-- field_name|section_name) tuple identifies the thread it belongs to,
+-- reusing the same rec_id scheme already used by the audit log:
+--     ZDB-LINESUBMISSION-…   top-level submission
+--     ZIRC-MUT-<id>          mutation
+--     ZIRC-GENE-<id>         gene
+--     ZIRC-LESION-<id>       lesion
+--     ZIRC-GA-<id>           genotyping assay
+--     ZIRC-PHEN-<id>         phenotype
+--     ZIRC-LF-<a>-<b>        linked feature pair
+--
+-- Field-scope comments fill lsc_field_name; section-scope comments fill
+-- lsc_section_name. A CHECK constraint enforces exactly one of the two
+-- is non-null and matches lsc_scope.
+
+--changeset cmpich:zirc-line-submission-comment-schema
+CREATE TABLE zirc.line_submission_comment (
+    lsc_pk_id        BIGSERIAL    PRIMARY KEY,
+    lsc_rec_id       TEXT         NOT NULL,
+    lsc_scope        TEXT         NOT NULL
+                                  CONSTRAINT lsc_scope_check
+                                  CHECK (lsc_scope IN ('field', 'section')),
+    lsc_field_name   TEXT,
+    lsc_section_name TEXT,
+    lsc_author_zdb_id TEXT        NOT NULL
+                                  CONSTRAINT lsc_author_fk
+                                  REFERENCES person(zdb_id)
+                                  ON UPDATE RESTRICT ON DELETE RESTRICT,
+    lsc_comment      TEXT         NOT NULL,
+    lsc_created_at   TIMESTAMP(3) NOT NULL DEFAULT now(),
+    CONSTRAINT lsc_scope_target_check CHECK (
+        (lsc_scope = 'field'   AND lsc_field_name   IS NOT NULL AND lsc_section_name IS NULL)
+     OR (lsc_scope = 'section' AND lsc_section_name IS NOT NULL AND lsc_field_name   IS NULL)
+    )
+);
+
+CREATE INDEX line_submission_comment_field_idx
+    ON zirc.line_submission_comment (lsc_rec_id, lsc_field_name)
+ WHERE lsc_scope = 'field';
+
+CREATE INDEX line_submission_comment_section_idx
+    ON zirc.line_submission_comment (lsc_rec_id, lsc_section_name)
+ WHERE lsc_scope = 'section';

--- a/source/org/zfin/db/postGmakePostloaddb/1182/migrations/0070-ZFIN-10304-zirc-section-approval.sql
+++ b/source/org/zfin/db/postGmakePostloaddb/1182/migrations/0070-ZFIN-10304-zirc-section-approval.sql
@@ -1,0 +1,26 @@
+--liquibase formatted sql
+
+-- Per-section curator-approval flag for a line submission. One row per
+-- (rec_id, section_name) tuple. rec_id reuses the audit-log identifier
+-- scheme (ZDB-LINESUBMISSION-…, ZIRC-MUT-N, …) so we can approve at
+-- both the submission level and the per-mutation inner sections.
+--
+-- Toggling the flag also writes a row to the updates table (server-side)
+-- so the history popup picks it up alongside other field changes.
+
+--changeset cmpich:zirc-line-submission-section-approval-schema
+CREATE TABLE zirc.line_submission_section_approval (
+    lssa_pk_id           BIGSERIAL    PRIMARY KEY,
+    lssa_rec_id          TEXT         NOT NULL,
+    lssa_section_name    TEXT         NOT NULL,
+    lssa_approved        BOOLEAN      NOT NULL DEFAULT FALSE,
+    lssa_approver_zdb_id TEXT         NOT NULL
+                                      CONSTRAINT lssa_approver_fk
+                                      REFERENCES person(zdb_id)
+                                      ON UPDATE RESTRICT ON DELETE RESTRICT,
+    lssa_approved_at     TIMESTAMP(3) NOT NULL DEFAULT now(),
+    CONSTRAINT lssa_rec_section_unique UNIQUE (lssa_rec_id, lssa_section_name)
+);
+
+CREATE INDEX line_submission_section_approval_rec_idx
+    ON zirc.line_submission_section_approval (lssa_rec_id);

--- a/source/org/zfin/db/postGmakePostloaddb/1182/run_zfin10241_backfill.sh
+++ b/source/org/zfin/db/postGmakePostloaddb/1182/run_zfin10241_backfill.sh
@@ -49,7 +49,10 @@ hdr "ZFIN-10241 backfill — preflight checks"
 
 PMID_FILE="$SOURCEROOT/$PMID_FILE_REL"
 PUBMED_DIR="$TARGETROOT/server_apps/data_transfer/PUBMED"
-WAR_LIB="$TARGETROOT/home/WEB-INF"
+# WAR_LIB defaults to the schlapp/dev exploded layout under $TARGETROOT;
+# trunk + other environments where the WAR lives under catalina_bases can
+# override with e.g.  WAR_LIB=/opt/zfin/catalina_bases/zfin.org/webapps/ROOT/WEB-INF
+WAR_LIB="${WAR_LIB:-$TARGETROOT/home/WEB-INF}"
 CP="$WAR_LIB/classes:$WAR_LIB/lib/*"
 
 [[ -f "$PMID_FILE" ]] || { red "missing PMID list: $PMID_FILE"; exit 1; }

--- a/source/org/zfin/zirc/entity/LineSubmissionComment.java
+++ b/source/org/zfin/zirc/entity/LineSubmissionComment.java
@@ -1,0 +1,54 @@
+package org.zfin.zirc.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.zfin.profile.Person;
+
+import java.util.Date;
+
+/**
+ * Curator/submitter comment thread row attached to a line-submission field
+ * or section. See migration 0060 for column docs and the rec_id scheme.
+ */
+@Entity(name = "ZircLineSubmissionComment")
+@Table(schema = "zirc", name = "line_submission_comment")
+@Getter
+@Setter
+public class LineSubmissionComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "lsc_pk_id")
+    private Long id;
+
+    @Column(name = "lsc_rec_id", nullable = false)
+    private String recId;
+
+    @Column(name = "lsc_scope", nullable = false)
+    private String scope;
+
+    @Column(name = "lsc_field_name")
+    private String fieldName;
+
+    @Column(name = "lsc_section_name")
+    private String sectionName;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "lsc_author_zdb_id", referencedColumnName = "zdb_id", nullable = false)
+    private Person author;
+
+    @Column(name = "lsc_comment", nullable = false)
+    private String comment;
+
+    @Column(name = "lsc_created_at", insertable = false, updatable = false)
+    private Date createdAt;
+}

--- a/source/org/zfin/zirc/entity/LineSubmissionSectionApproval.java
+++ b/source/org/zfin/zirc/entity/LineSubmissionSectionApproval.java
@@ -43,6 +43,11 @@ public class LineSubmissionSectionApproval {
     @JoinColumn(name = "lssa_approver_zdb_id", referencedColumnName = "zdb_id", nullable = false)
     private Person approver;
 
-    @Column(name = "lssa_approved_at", insertable = false, updatable = false)
+    // Last-toggle timestamp. The migration sets a now() default so the
+    // first INSERT lands at row creation; subsequent UPDATEs MUST refresh
+    // it explicitly (handled by ZircDashboardController.setSectionApproval).
+    // Hibernate-side insertable/updatable both true so the explicit set
+    // is honored.
+    @Column(name = "lssa_approved_at", nullable = false)
     private Date approvedAt;
 }

--- a/source/org/zfin/zirc/entity/LineSubmissionSectionApproval.java
+++ b/source/org/zfin/zirc/entity/LineSubmissionSectionApproval.java
@@ -1,0 +1,48 @@
+package org.zfin.zirc.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import org.zfin.profile.Person;
+
+import java.util.Date;
+
+/**
+ * Per-section curator-approval state for a line submission. One row per
+ * (rec_id, section_name). See migration 0070 for the rec_id scheme.
+ */
+@Entity(name = "ZircLineSubmissionSectionApproval")
+@Table(schema = "zirc", name = "line_submission_section_approval")
+@Getter
+@Setter
+public class LineSubmissionSectionApproval {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "lssa_pk_id")
+    private Long id;
+
+    @Column(name = "lssa_rec_id", nullable = false)
+    private String recId;
+
+    @Column(name = "lssa_section_name", nullable = false)
+    private String sectionName;
+
+    @Column(name = "lssa_approved", nullable = false)
+    private boolean approved;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "lssa_approver_zdb_id", referencedColumnName = "zdb_id", nullable = false)
+    private Person approver;
+
+    @Column(name = "lssa_approved_at", insertable = false, updatable = false)
+    private Date approvedAt;
+}

--- a/source/org/zfin/zirc/presentation/ZircDashboardController.java
+++ b/source/org/zfin/zirc/presentation/ZircDashboardController.java
@@ -11,6 +11,7 @@ import org.zfin.framework.HibernateUtil;
 import org.zfin.framework.presentation.LookupStrings;
 import org.zfin.infrastructure.Updates;
 import org.zfin.profile.Person;
+import org.zfin.repository.RepositoryFactory;
 import org.zfin.profile.service.ProfileService;
 import org.zfin.zirc.entity.LineSubmission;
 import org.zfin.zirc.entity.LineSubmissionPerson;
@@ -355,6 +356,117 @@ public class ZircDashboardController {
         // Whole-submission roll-up: every audited change anywhere on this
         // submission (already DESC-sorted by the query above).
         model.addAttribute("submissionAllUpdates", allUpdates);
+
+        // Per-section approval state. Loaded for the submission + each
+        // mutation so the JSP can render initial checkbox state on every
+        // section header. Key format: "<recId>|<sectionName>".
+        List<Object[]> approvalRows = HibernateUtil.currentSession()
+                .createQuery(
+                    "select recId, sectionName, approved from ZircLineSubmissionSectionApproval "
+                  + "where recId in :rids",
+                    Object[].class)
+                .setParameterList("rids", auditKeys)
+                .list();
+        Map<String, Boolean> sectionApprovals = new LinkedHashMap<>();
+        for (Object[] r : approvalRows) {
+            sectionApprovals.put(r[0] + "|" + r[1], (Boolean) r[2]);
+        }
+        model.addAttribute("sectionApprovals", sectionApprovals);
+
+        // Overlay APPROVED onto the section status maps so the rollup
+        // badges reflect curator approval. The slug-to-label mapping
+        // mirrors the JSP's section names.
+        Map<String, String> SLUG_TO_SECTION = Map.ofEntries(
+                Map.entry("overview",          "Overview"),
+                Map.entry("mutations",         "Mutations"),
+                Map.entry("linked-features",   "Linked Features"),
+                Map.entry("background",        "Background"),
+                Map.entry("additional-info",   "Additional Info"),
+                Map.entry("genes",             "Genes"),
+                Map.entry("lesions",           "Lesions"),
+                Map.entry("genotyping-assays", "Genotyping Assays"),
+                Map.entry("phenotypes",        "Phenotypes"),
+                Map.entry("lethality",         "Lethality"),
+                Map.entry("publications",      "Publications"));
+        for (Map.Entry<String, Boolean> e : sectionApprovals.entrySet()) {
+            if (!Boolean.TRUE.equals(e.getValue())) continue;
+            String[] parts = e.getKey().split("\\|", 2);
+            if (parts.length != 2) continue;
+            String recIdKey  = parts[0];
+            String slug      = parts[1];
+            String sectionLabel = SLUG_TO_SECTION.get(slug);
+            if (submission.getZdbID().equals(recIdKey)) {
+                if (sectionLabel != null) {
+                    status.bySection().put(sectionLabel, FieldStatus.APPROVED);
+                }
+            } else if (recIdKey.startsWith("ZIRC-MUT-")) {
+                Long mid;
+                try { mid = Long.parseLong(recIdKey.substring("ZIRC-MUT-".length())); }
+                catch (NumberFormatException nfe) { continue; }
+                if ("mutation".equals(slug)) {
+                    // The mutation header itself
+                    mutationStatus.put(mid, FieldStatus.APPROVED);
+                    subSectionStatus.replaceAll((label, st) -> {
+                        // subSectionStatus is keyed by "Mutation N" labels; we
+                        // can't easily reverse the id, but the per-mutation
+                        // loop above already populated it from r.overall().
+                        // Cheaper to just look the id up via mutationLabels.
+                        return st;
+                    });
+                } else if (sectionLabel != null) {
+                    Map<String, FieldStatus> bySect = mutationSectionStatus.get(mid);
+                    if (bySect != null) bySect.put(sectionLabel, FieldStatus.APPROVED);
+                }
+            }
+        }
+        // Re-roll the parent statuses upward so a section reads APPROVED
+        // when all its children are. mutation overall = worst-of inner
+        // sections; "Mutations" = worst-of all mutations (or MISSING when
+        // none exist); overallStatus = worst-of all top-level sections.
+        // An explicit approval on the parent itself never gets downgraded.
+        for (Map.Entry<Long, Map<String, FieldStatus>> e : mutationSectionStatus.entrySet()) {
+            FieldStatus worst = FieldStatus.APPROVED;
+            for (FieldStatus s : e.getValue().values()) {
+                if (s != null) worst = worst.worse(s);
+            }
+            if (Boolean.TRUE.equals(sectionApprovals.get("ZIRC-MUT-" + e.getKey() + "|mutation"))) {
+                worst = FieldStatus.APPROVED;
+            }
+            mutationStatus.put(e.getKey(), worst);
+        }
+        // Recompute top-level "Mutations": presence-check + worst-of-mutations.
+        FieldStatus mutsRollup;
+        if (mutationStatus.isEmpty()) {
+            mutsRollup = FieldStatus.MISSING;
+        } else {
+            mutsRollup = FieldStatus.APPROVED;
+            for (FieldStatus s : mutationStatus.values()) {
+                if (s != null) mutsRollup = mutsRollup.worse(s);
+            }
+        }
+        if (Boolean.TRUE.equals(sectionApprovals.get(submission.getZdbID() + "|mutations"))) {
+            mutsRollup = FieldStatus.APPROVED;
+        }
+        status.bySection().put("Mutations", mutsRollup);
+
+        // Refresh subSectionStatus from the (now potentially-approved)
+        // mutationStatus map so the left-nav "Mutation N" entries pick up
+        // approved coloring too.
+        if (submission.getMutations() != null) {
+            int i = 1;
+            for (Mutation mut : submission.getMutations()) {
+                String label = "Mutation " + i++;
+                FieldStatus st = mutationStatus.get(mut.getId());
+                if (st != null) subSectionStatus.put(label, st);
+            }
+        }
+
+        // Recompute page-overall from the (now potentially-approved) top-level sections.
+        FieldStatus pageOverall = FieldStatus.APPROVED;
+        for (FieldStatus s : status.bySection().values()) {
+            if (s != null) pageOverall = pageOverall.worse(s);
+        }
+        model.addAttribute("overallStatus", pageOverall);
 
         model.addAttribute("mutationStatus", mutationStatus);
         model.addAttribute("mutationFieldStatus", mutationFieldStatus);
@@ -837,6 +949,176 @@ public class ZircDashboardController {
                     mutationId, req.path, req.value, currentUser);
             HibernateUtil.flushAndCommitCurrentSession();
             return MutationDTO.from(m);
+        } catch (RuntimeException e) {
+            HibernateUtil.rollbackTransaction();
+            throw e;
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Curator/submitter comment threads (per-field + per-section).
+    //
+    // Threads are addressed by (recId, scope, fieldName | sectionName).
+    // recId reuses the existing audit identifier scheme so a comment can
+    // attach to a top-level field (recId = ZDB-LINESUBMISSION-…), a
+    // mutation (ZIRC-MUT-N), a gene/lesion/assay/phenotype, or a linked
+    // feature.
+    // ──────────────────────────────────────────────────────────────────
+
+    /** JSON shape returned by the comment list endpoint. */
+    public static record CommentDTO(Long id,
+                                    String author,        // display name "F. Last"
+                                    String authorZdbId,
+                                    String comment,
+                                    String createdAt) {}  // ISO-8601
+
+    private static CommentDTO toDto(org.zfin.zirc.entity.LineSubmissionComment c) {
+        String displayName;
+        if (c.getAuthor() == null) {
+            displayName = "Unknown";
+        } else {
+            String first = c.getAuthor().getFirstName();
+            String last  = c.getAuthor().getLastName();
+            String initial = (first != null && !first.isBlank()) ? first.substring(0, 1) + ". " : "";
+            displayName = (initial + (last == null ? "" : last)).trim();
+            if (displayName.isEmpty()) displayName = c.getAuthor().getFullName();
+        }
+        return new CommentDTO(
+                c.getId(),
+                displayName,
+                c.getAuthor() == null ? null : c.getAuthor().getZdbID(),
+                c.getComment(),
+                c.getCreatedAt() == null ? null : c.getCreatedAt().toInstant().toString());
+    }
+
+    @GetMapping("/comments")
+    @ResponseBody
+    public List<CommentDTO> listComments(@RequestParam("recId") String recId,
+                                         @RequestParam("scope") String scope,
+                                         @RequestParam(value = "fieldName",   required = false) String fieldName,
+                                         @RequestParam(value = "sectionName", required = false) String sectionName) {
+        if (!"field".equals(scope) && !"section".equals(scope)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "scope must be 'field' or 'section'");
+        }
+        String hql = "from ZircLineSubmissionComment where recId = :rid and scope = :scope and "
+                + ("field".equals(scope) ? "fieldName = :name" : "sectionName = :name")
+                + " order by createdAt asc, id asc";
+        String name = "field".equals(scope) ? fieldName : sectionName;
+        if (name == null || name.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "fieldName (scope=field) or sectionName (scope=section) is required");
+        }
+        List<org.zfin.zirc.entity.LineSubmissionComment> rows =
+                HibernateUtil.currentSession()
+                        .createQuery(hql, org.zfin.zirc.entity.LineSubmissionComment.class)
+                        .setParameter("rid", recId)
+                        .setParameter("scope", scope)
+                        .setParameter("name", name)
+                        .list();
+        List<CommentDTO> out = new ArrayList<>(rows.size());
+        for (org.zfin.zirc.entity.LineSubmissionComment c : rows) out.add(toDto(c));
+        return out;
+    }
+
+    @PostMapping("/comments")
+    @ResponseBody
+    public CommentDTO addComment(@RequestParam("recId") String recId,
+                                 @RequestParam("scope") String scope,
+                                 @RequestParam(value = "fieldName",   required = false) String fieldName,
+                                 @RequestParam(value = "sectionName", required = false) String sectionName,
+                                 @RequestParam("comment") String comment) {
+        if (!"field".equals(scope) && !"section".equals(scope)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "scope must be 'field' or 'section'");
+        }
+        String name = "field".equals(scope) ? fieldName : sectionName;
+        if (name == null || name.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "fieldName (scope=field) or sectionName (scope=section) is required");
+        }
+        if (comment == null || comment.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "comment must not be empty");
+        }
+        Person currentUser = ProfileService.getCurrentSecurityUser();
+        if (currentUser == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Login required to comment");
+        }
+        HibernateUtil.createTransaction();
+        try {
+            org.zfin.zirc.entity.LineSubmissionComment c = new org.zfin.zirc.entity.LineSubmissionComment();
+            c.setRecId(recId);
+            c.setScope(scope);
+            if ("field".equals(scope)) c.setFieldName(name);
+            else                       c.setSectionName(name);
+            c.setAuthor(HibernateUtil.currentSession().getReference(Person.class, currentUser.getZdbID()));
+            c.setComment(comment.trim());
+            HibernateUtil.currentSession().persist(c);
+            HibernateUtil.flushAndCommitCurrentSession();
+            return toDto(c);
+        } catch (RuntimeException e) {
+            HibernateUtil.rollbackTransaction();
+            throw e;
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Per-section curator-approval flag.
+    // Upserts a row in zirc.line_submission_section_approval and also
+    // writes an audit-log entry so the existing history popups pick it
+    // up. recId reuses the audit identifier scheme (so we can approve
+    // submission-level sections AND per-mutation inner sections with
+    // the same endpoint).
+    // ──────────────────────────────────────────────────────────────────
+
+    public static record SectionApprovalDTO(String recId,
+                                            String sectionName,
+                                            boolean approved,
+                                            String approver,
+                                            String approvedAt) {}
+
+    @PostMapping("/section-approval")
+    @ResponseBody
+    public SectionApprovalDTO setSectionApproval(@RequestParam("recId") String recId,
+                                                 @RequestParam("sectionName") String sectionName,
+                                                 @RequestParam("approved") boolean approved) {
+        if (recId == null || recId.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "recId required");
+        }
+        if (sectionName == null || sectionName.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "sectionName required");
+        }
+        Person currentUser = ProfileService.getCurrentSecurityUser();
+        if (currentUser == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Login required");
+        }
+        HibernateUtil.createTransaction();
+        try {
+            org.zfin.zirc.entity.LineSubmissionSectionApproval row = HibernateUtil.currentSession()
+                    .createQuery(
+                        "from ZircLineSubmissionSectionApproval where recId = :rid and sectionName = :sn",
+                        org.zfin.zirc.entity.LineSubmissionSectionApproval.class)
+                    .setParameter("rid", recId)
+                    .setParameter("sn", sectionName)
+                    .uniqueResult();
+            boolean oldApproved = row != null && row.isApproved();
+            if (row == null) {
+                row = new org.zfin.zirc.entity.LineSubmissionSectionApproval();
+                row.setRecId(recId);
+                row.setSectionName(sectionName);
+            }
+            row.setApproved(approved);
+            row.setApprover(HibernateUtil.currentSession().getReference(Person.class, currentUser.getZdbID()));
+            HibernateUtil.currentSession().merge(row);
+            if (oldApproved != approved) {
+                RepositoryFactory.getInfrastructureRepository().insertUpdatesTable(
+                        recId, "section.approved." + sectionName,
+                        Boolean.toString(oldApproved), Boolean.toString(approved),
+                        "Section " + sectionName + (approved ? " approved" : " un-approved"));
+            }
+            HibernateUtil.flushAndCommitCurrentSession();
+            String approverName = currentUser.getFullName();
+            return new SectionApprovalDTO(recId, sectionName, approved,
+                    approverName,
+                    row.getApprovedAt() == null ? null : row.getApprovedAt().toInstant().toString());
         } catch (RuntimeException e) {
             HibernateUtil.rollbackTransaction();
             throw e;

--- a/source/org/zfin/zirc/presentation/ZircDashboardController.java
+++ b/source/org/zfin/zirc/presentation/ZircDashboardController.java
@@ -1068,6 +1068,29 @@ public class ZircDashboardController {
                                             String approver,
                                             String approvedAt) {}
 
+    // Allowlist of valid section slugs (mirrors what the JSP emits).
+    private static final java.util.Set<String> TOP_LEVEL_SECTION_SLUGS = java.util.Set.of(
+            "overview", "mutations", "linked-features", "background", "additional-info");
+    private static final java.util.Set<String> MUTATION_SECTION_SLUGS = java.util.Set.of(
+            "mutation", "overview", "genes", "lesions",
+            "genotyping-assays", "phenotypes", "lethality", "publications");
+    private static final java.util.Map<String, String> SECTION_SLUG_TO_LABEL = java.util.Map.ofEntries(
+            java.util.Map.entry("overview",          "Overview"),
+            java.util.Map.entry("mutations",         "Mutations"),
+            java.util.Map.entry("linked-features",   "Linked Features"),
+            java.util.Map.entry("background",        "Background"),
+            java.util.Map.entry("additional-info",   "Additional Info"),
+            java.util.Map.entry("genes",             "Genes"),
+            java.util.Map.entry("lesions",           "Lesions"),
+            java.util.Map.entry("genotyping-assays", "Genotyping Assays"),
+            java.util.Map.entry("phenotypes",        "Phenotypes"),
+            java.util.Map.entry("lethality",         "Lethality"),
+            java.util.Map.entry("publications",      "Publications"));
+    private static final java.util.regex.Pattern LSUB_REC_ID_PATTERN =
+            java.util.regex.Pattern.compile("^ZDB-LINESUBMISSION-\\d{6}-\\d+$");
+    private static final java.util.regex.Pattern MUT_REC_ID_PATTERN =
+            java.util.regex.Pattern.compile("^ZIRC-MUT-(\\d+)$");
+
     @PostMapping("/section-approval")
     @ResponseBody
     public SectionApprovalDTO setSectionApproval(@RequestParam("recId") String recId,
@@ -1082,6 +1105,50 @@ public class ZircDashboardController {
         Person currentUser = ProfileService.getCurrentSecurityUser();
         if (currentUser == null) {
             throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Login required");
+        }
+        // Only curators may flip approvals.
+        if (currentUser.getAccountInfo() == null || !currentUser.getAccountInfo().isCurator()) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Curator role required");
+        }
+        // Validate (recId, sectionName) and resolve owning submission.
+        LineSubmission owningSubmission;
+        java.util.regex.Matcher mutMatch = MUT_REC_ID_PATTERN.matcher(recId);
+        if (LSUB_REC_ID_PATTERN.matcher(recId).matches()) {
+            if (!TOP_LEVEL_SECTION_SLUGS.contains(sectionName)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Unknown top-level section: " + sectionName);
+            }
+            owningSubmission = HibernateUtil.currentSession().get(LineSubmission.class, recId);
+            if (owningSubmission == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Submission " + recId + " not found");
+            }
+        } else if (mutMatch.matches()) {
+            if (!MUTATION_SECTION_SLUGS.contains(sectionName)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Unknown mutation section: " + sectionName);
+            }
+            Long mutId = Long.parseLong(mutMatch.group(1));
+            Mutation mut = HibernateUtil.currentSession().get(Mutation.class, mutId);
+            if (mut == null) {
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Mutation " + mutId + " not found");
+            }
+            owningSubmission = mut.getLineSubmission();
+        } else {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "recId must be ZDB-LINESUBMISSION-* or ZIRC-MUT-*");
+        }
+        // Server-side rollup check: only allow approved=true when the
+        // section's underlying status is already COMPLETE (or already
+        // APPROVED — the latter lets an idempotent re-approval succeed
+        // even if the overlay has already promoted the rollup). Un-approval
+        // is always allowed.
+        if (approved) {
+            FieldStatus rollup = resolveSectionRollup(owningSubmission, recId, sectionName);
+            if (rollup == null
+                    || (rollup != FieldStatus.COMPLETE && rollup != FieldStatus.APPROVED)) {
+                throw new ResponseStatusException(HttpStatus.CONFLICT,
+                        "Section " + sectionName + " is not Complete; cannot approve");
+            }
         }
         HibernateUtil.createTransaction();
         try {
@@ -1100,7 +1167,9 @@ public class ZircDashboardController {
             }
             row.setApproved(approved);
             row.setApprover(HibernateUtil.currentSession().getReference(Person.class, currentUser.getZdbID()));
-            HibernateUtil.currentSession().merge(row);
+            row.setApprovedAt(new java.util.Date());
+            row = (org.zfin.zirc.entity.LineSubmissionSectionApproval)
+                    HibernateUtil.currentSession().merge(row);
             if (oldApproved != approved) {
                 RepositoryFactory.getInfrastructureRepository().insertUpdatesTable(
                         recId, "section.approved." + sectionName,
@@ -1116,5 +1185,32 @@ public class ZircDashboardController {
             HibernateUtil.rollbackTransaction();
             throw e;
         }
+    }
+
+    /** Resolve the current rollup status for (recId, sectionName) by running the
+     *  relevant status computer on the owning submission. Returns null if the
+     *  section can't be located. Pre-approval-overlay value — the caller decides
+     *  whether to allow the toggle based on it. */
+    private FieldStatus resolveSectionRollup(LineSubmission submission, String recId, String sectionName) {
+        String label = SECTION_SLUG_TO_LABEL.get(sectionName);
+        if (LSUB_REC_ID_PATTERN.matcher(recId).matches()) {
+            if (label == null) return null;
+            FieldStatusResult r = LineSubmissionStatusComputer.compute(submission);
+            return r.bySection().get(label);
+        }
+        java.util.regex.Matcher m = MUT_REC_ID_PATTERN.matcher(recId);
+        if (m.matches()) {
+            long mid = Long.parseLong(m.group(1));
+            Mutation mut = submission.getMutations() == null ? null :
+                    submission.getMutations().stream()
+                            .filter(x -> x.getId() == mid).findFirst().orElse(null);
+            if (mut == null) return null;
+            FieldStatusResult r = MutationStatusComputer.compute(mut);
+            if ("mutation".equals(sectionName)) {
+                return r.overall();
+            }
+            return label == null ? null : r.bySection().get(label);
+        }
+        return null;
     }
 }

--- a/source/org/zfin/zirc/presentation/ZircDashboardController.java
+++ b/source/org/zfin/zirc/presentation/ZircDashboardController.java
@@ -406,13 +406,6 @@ public class ZircDashboardController {
                 if ("mutation".equals(slug)) {
                     // The mutation header itself
                     mutationStatus.put(mid, FieldStatus.APPROVED);
-                    subSectionStatus.replaceAll((label, st) -> {
-                        // subSectionStatus is keyed by "Mutation N" labels; we
-                        // can't easily reverse the id, but the per-mutation
-                        // loop above already populated it from r.overall().
-                        // Cheaper to just look the id up via mutationLabels.
-                        return st;
-                    });
                 } else if (sectionLabel != null) {
                     Map<String, FieldStatus> bySect = mutationSectionStatus.get(mid);
                     if (bySect != null) bySect.put(sectionLabel, FieldStatus.APPROVED);


### PR DESCRIPTION
- Per-field/per-section curator/submitter comment threads (new zirc.line_submission_comment table, REST endpoints, shared modal opened from a hover-revealed comments icon).
- Per-section Approved checkbox (new zirc.line_submission_section_approval) enabled only when rollup status is Complete; toggling propagates to parent section badges and the overall page status; each toggle is logged to the updates audit table.
- Page-top Status Overview bar that mirrors the top-level sections with Missing/In-Progress/Complete/Approved colors and an inline status legend.
- web.xml: UTF-8 jsp-config so literal non-ASCII characters in JSPs render correctly.
- run_zfin10241_backfill.sh: WAR_LIB env-var override so the script works in environments whose deployed WAR lives outside TARGETROOT.